### PR TITLE
interfaces: support static addressing in assignment API

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/Interfaces/NetworkInterface.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Interfaces/NetworkInterface.php
@@ -140,6 +140,13 @@ class NetworkInterface extends BaseModel
                     if ($model_interfaces[$key]->$field->isFieldChanged()) {
                         $value = $interfaces[$key][$field];
                         if ($value === '') {
+                            if (
+                                in_array($field, ['ipaddr', 'ipaddrv6']) &&
+                                (string)$intf->$field !== '' &&
+                                filter_var((string)$intf->$field, FILTER_VALIDATE_IP) === false
+                            ) {
+                                continue;
+                            }
                             unset($intf->$field);
                         } else {
                             $intf->$field = $value;

--- a/src/opnsense/mvc/app/models/OPNsense/Interfaces/NetworkInterface.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Interfaces/NetworkInterface.php
@@ -100,6 +100,17 @@ class NetworkInterface extends BaseModel
             $node->descr = (string)$intf->descr;
             $node->identifier = $key;
             $node->lock = empty((string)$intf->lock) ? '0' : '1';
+            foreach (['' => FILTER_FLAG_IPV4, 'v6' => FILTER_FLAG_IPV6] as $suffix => $filter_flag) {
+                $addr_field = 'ipaddr' . $suffix;
+                $subnet_field = 'subnet' . $suffix;
+                $gateway_field = 'gateway' . $suffix;
+                $address = (string)$intf->$addr_field;
+                if ($address !== '' && filter_var($address, FILTER_VALIDATE_IP, $filter_flag) !== false) {
+                    $node->$addr_field = $address;
+                    $node->$subnet_field = (string)$intf->$subnet_field;
+                    $node->$gateway_field = (string)$intf->$gateway_field;
+                }
+            }
             if (isset($iftodo['pending_if'])) {
                 $node->if = $iftodo['pending_if'];
             } else {
@@ -118,12 +129,23 @@ class NetworkInterface extends BaseModel
         $interfaces = $this->interface->getNodeContent();
         $existing_ifnames = [];
         /* mark pending actions as we need to wait for "apply" in order to persist them */
+        $model_interfaces = iterator_to_array($this->interface->iterateItems());
         foreach ($this->iterate_assignments() as $key => $intf) {
             if (!isset($interfaces[$key])) {
                 $this->store_if_todo($key, ['pending_action' => 'delete']);
             } else {
                 $intf->descr = $interfaces[$key]['descr'];
                 $intf->lock = $interfaces[$key]['lock'];
+                foreach (['ipaddr', 'subnet', 'gateway', 'ipaddrv6', 'subnetv6', 'gatewayv6'] as $field) {
+                    if ($model_interfaces[$key]->$field->isFieldChanged()) {
+                        $value = $interfaces[$key][$field];
+                        if ($value === '') {
+                            unset($intf->$field);
+                        } else {
+                            $intf->$field = $value;
+                        }
+                    }
+                }
                 /* flush actions that need to be applied, for which we need history */
                 if ($intf->if != $interfaces[$key]['if']) {
                     $this->store_if_todo($key, ['pending_action' => 'relink', 'pending_if' => $interfaces[$key]['if']]);
@@ -142,6 +164,11 @@ class NetworkInterface extends BaseModel
                 $newif->if = $intf['if'];
                 $newif->descr = $intf['descr'];
                 $newif->lock = $intf['lock'];
+                foreach (['ipaddr', 'subnet', 'gateway', 'ipaddrv6', 'subnetv6', 'gatewayv6'] as $field) {
+                    if ($intf[$field] !== '') {
+                        $newif->$field = $intf[$field];
+                    }
+                }
                 $next_if++;
             }
         }
@@ -156,6 +183,38 @@ class NetworkInterface extends BaseModel
                 continue;
             }
             $key = $if->__reference;
+            foreach ([['ipaddr', 'subnet'], ['ipaddrv6', 'subnetv6']] as $fields) {
+                $has_address = $if->{$fields[0]}->getValue() !== '';
+                $has_prefix = $if->{$fields[1]}->getValue() !== '';
+                if ($has_address !== $has_prefix) {
+                    $msg = gettext('A static IP address and its prefix length must be configured together.');
+                    $messages->appendMessage(new Message($msg, $key . '.' . $fields[0]));
+                    $messages->appendMessage(new Message($msg, $key . '.' . $fields[1]));
+                }
+            }
+            foreach ([['gateway', 'ipaddr', 'inet'], ['gatewayv6', 'ipaddrv6', 'inet6']] as $fields) {
+                $gateway = $if->{$fields[0]}->getValue();
+                if ($gateway !== '' && $if->{$fields[1]}->getValue() === '') {
+                    $msg = gettext('A gateway requires a static IP address of the same address family.');
+                    $messages->appendMessage(new Message($msg, $key . '.' . $fields[0]));
+                } elseif ($gateway !== '') {
+                    $gateway_found = false;
+                    foreach (Config::getInstance()->object()->xpath('//OPNsense/Gateways/gateway_item') as $gateway_node) {
+                        if (
+                            (string)$gateway_node->name === $gateway &&
+                            (string)$gateway_node->interface === $ifname &&
+                            (string)$gateway_node->ipprotocol === $fields[2]
+                        ) {
+                            $gateway_found = true;
+                            break;
+                        }
+                    }
+                    if (!$gateway_found) {
+                        $msg = gettext('The selected gateway does not exist for this interface and address family.');
+                        $messages->appendMessage(new Message($msg, $key . '.' . $fields[0]));
+                    }
+                }
+            }
             if (preg_match('/^bridge[0-9]/', $if->if->getValue())) {
                 foreach (Config::getInstance()->object()->xpath('/*/bridges/bridged') as $node) {
                     if (in_array($ifname, explode(',', $node->members))) {

--- a/src/opnsense/mvc/app/models/OPNsense/Interfaces/NetworkInterface.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Interfaces/NetworkInterface.php
@@ -44,6 +44,19 @@ class NetworkInterface extends BaseModel
     {
         $fobj = new FileObject($this->todo_file, 'a+', 0600, LOCK_EX);
         $data = $fobj->readJson() ?? [];
+        $current_action = $data[$id]['pending_action'] ?? '';
+        if (
+            ($payload['pending_action'] ?? '') == 'reconfigure' &&
+            in_array($current_action, ['delete', 'relink'])
+        ) {
+            unset($payload['pending_action']);
+        }
+        if (!empty($payload['pending_families'])) {
+            $payload['pending_families'] = array_values(array_unique(array_merge(
+                $data[$id]['pending_families'] ?? [],
+                $payload['pending_families']
+            )));
+        }
         $data[$id] = array_merge($data[$id] ?? [], $payload);
         $fobj->truncate(0)->writeJson($data);
     }
@@ -110,6 +123,9 @@ class NetworkInterface extends BaseModel
                     $node->$subnet_field = (string)$intf->$subnet_field;
                     $node->$gateway_field = (string)$intf->$gateway_field;
                 }
+                $node->$addr_field->markUnchanged();
+                $node->$subnet_field->markUnchanged();
+                $node->$gateway_field->markUnchanged();
             }
             if (isset($iftodo['pending_if'])) {
                 $node->if = $iftodo['pending_if'];
@@ -136,8 +152,10 @@ class NetworkInterface extends BaseModel
             } else {
                 $intf->descr = $interfaces[$key]['descr'];
                 $intf->lock = $interfaces[$key]['lock'];
+                $changed_families = [];
                 foreach (['ipaddr', 'subnet', 'gateway', 'ipaddrv6', 'subnetv6', 'gatewayv6'] as $field) {
                     if ($model_interfaces[$key]->$field->isFieldChanged()) {
+                        $changed_families[] = substr($field, -2) == 'v6' ? 6 : 4;
                         $value = $interfaces[$key][$field];
                         if ($value === '') {
                             if (
@@ -152,6 +170,12 @@ class NetworkInterface extends BaseModel
                             $intf->$field = $value;
                         }
                     }
+                }
+                if (!empty($changed_families)) {
+                    $this->store_if_todo($key, [
+                        'pending_action' => 'reconfigure',
+                        'pending_families' => array_values(array_unique($changed_families))
+                    ]);
                 }
                 /* flush actions that need to be applied, for which we need history */
                 if ($intf->if != $interfaces[$key]['if']) {

--- a/src/opnsense/mvc/app/models/OPNsense/Interfaces/NetworkInterface.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Interfaces/NetworkInterface.xml
@@ -1,6 +1,6 @@
 <model>
     <mount>:memory:</mount>
-    <version>0.0.1</version>
+    <version>0.0.2</version>
     <description>Interface assignments</description>
     <items>
         <interface type="ArrayField">

--- a/src/opnsense/mvc/app/models/OPNsense/Interfaces/NetworkInterface.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Interfaces/NetworkInterface.xml
@@ -22,6 +22,26 @@
                 <Default>1</Default>
                 <Required>Y</Required>
             </lock>
+            <ipaddr type="NetworkField">
+                <AddressFamily>ipv4</AddressFamily>
+                <NetMaskAllowed>N</NetMaskAllowed>
+                <WildcardEnabled>N</WildcardEnabled>
+            </ipaddr>
+            <subnet type="IntegerField">
+                <MinimumValue>0</MinimumValue>
+                <MaximumValue>32</MaximumValue>
+            </subnet>
+            <gateway type="TextField"/>
+            <ipaddrv6 type="NetworkField">
+                <AddressFamily>ipv6</AddressFamily>
+                <NetMaskAllowed>N</NetMaskAllowed>
+                <WildcardEnabled>N</WildcardEnabled>
+            </ipaddrv6>
+            <subnetv6 type="IntegerField">
+                <MinimumValue>0</MinimumValue>
+                <MaximumValue>128</MaximumValue>
+            </subnetv6>
+            <gatewayv6 type="TextField"/>
         </interface>
     </items>
 </model>

--- a/src/opnsense/mvc/tests/api/interfaces_assignment_static_addressing.sh
+++ b/src/opnsense/mvc/tests/api/interfaces_assignment_static_addressing.sh
@@ -1,0 +1,129 @@
+#!/bin/sh
+set -eu
+
+: "${OPNSENSE_API_KEY:?Set OPNSENSE_API_KEY}"
+: "${OPNSENSE_API_SECRET:?Set OPNSENSE_API_SECRET}"
+
+BASE_URL=${OPNSENSE_URL:-http://127.0.0.1}
+IFACE=${OPNSENSE_TEST_INTERFACE:-lan}
+TEST_IPV4=${OPNSENSE_TEST_IPV4:-192.0.2.1}
+TEST_PREFIX4=${OPNSENSE_TEST_PREFIX4:-24}
+TEST_IPV6=${OPNSENSE_TEST_IPV6:-2001:db8:55::1}
+TEST_PREFIX6=${OPNSENSE_TEST_PREFIX6:-64}
+TMPDIR=$(mktemp -d /tmp/interfaces-api-test.XXXXXX)
+ORIGINAL="$TMPDIR/original.json"
+
+api_request() {
+    method=$1
+    path=$2
+    data=${3-}
+    if [ "$method" = GET ]; then
+        curl -fsS -u "$OPNSENSE_API_KEY:$OPNSENSE_API_SECRET" \
+            "$BASE_URL$path"
+    else
+        curl -fsS -u "$OPNSENSE_API_KEY:$OPNSENSE_API_SECRET" \
+            -H 'Content-Type: application/json' -X "$method" \
+            -d "$data" "$BASE_URL$path"
+    fi
+}
+assert_json() {
+    file=$1
+    expression=$2
+    if ! jq -e "$expression" "$file" >/dev/null; then
+        echo "Assertion failed: $expression" >&2
+        cat "$file" >&2
+        exit 1
+    fi
+}
+
+api_request GET "/api/interfaces/assignment/get_item/$IFACE" > "$ORIGINAL"
+DEVICE=$(jq -r '.interface.if | to_entries[] | select(.value.selected == 1) | .key' "$ORIGINAL")
+[ -n "$DEVICE" ] || { echo "Assigned device not found" >&2; exit 1; }
+
+RESTORE_PAYLOAD=$(jq -c '{interface: {
+    ipaddr: .interface.ipaddr,
+    subnet: .interface.subnet,
+    gateway: .interface.gateway,
+    ipaddrv6: .interface.ipaddrv6,
+    subnetv6: .interface.subnetv6,
+    gatewayv6: .interface.gatewayv6
+}}' "$ORIGINAL")
+
+cleanup() {
+    status=$?
+    trap - EXIT HUP INT TERM
+    set +e
+    restore_failed=0
+    if ! api_request POST "/api/interfaces/assignment/set_item/$IFACE" \
+        "$RESTORE_PAYLOAD" > "$TMPDIR/restore-set.json"; then
+        restore_failed=1
+    fi
+    if ! api_request POST '/api/interfaces/assignment/reconfigure' \
+        "$(jq -nc '{}')" > "$TMPDIR/restore-apply.json"; then
+        restore_failed=1
+    fi
+    if [ "$restore_failed" -ne 0 ]; then
+        echo "Rollback failed" >&2
+        status=1
+    else
+        echo "Rollback completed"
+    fi
+    rm -rf "$TMPDIR"
+    exit "$status"
+}
+trap cleanup EXIT HUP INT TERM
+
+INVALID_PAYLOAD=$(jq -nc \
+    --arg ipaddr '999.1.1.1' \
+    --arg subnet '24' \
+    '{interface:{ipaddr:$ipaddr,subnet:$subnet}}')
+api_request POST "/api/interfaces/assignment/set_item/$IFACE" \
+    "$INVALID_PAYLOAD" > "$TMPDIR/invalid.json"
+assert_json "$TMPDIR/invalid.json" \
+    '.result == "failed" and (.validations | length > 0)'
+echo "Invalid IPv4 validation: PASS"
+
+VALID_IPV6_PAYLOAD=$(jq -nc \
+    --arg ip6 "$TEST_IPV6" --arg prefix6 "$TEST_PREFIX6" \
+    '{interface:{ipaddrv6:$ip6,subnetv6:$prefix6,gatewayv6:""}}')
+api_request POST "/api/interfaces/assignment/set_item/$IFACE" \
+    "$VALID_IPV6_PAYLOAD" > "$TMPDIR/valid-set-v6.json"
+assert_json "$TMPDIR/valid-set-v6.json" '.result == "saved"'
+
+VALID_IPV4_PAYLOAD=$(jq -nc \
+    --arg ip4 "$TEST_IPV4" --arg prefix4 "$TEST_PREFIX4" \
+    '{interface:{ipaddr:$ip4,subnet:$prefix4,gateway:""}}')
+api_request POST "/api/interfaces/assignment/set_item/$IFACE" \
+    "$VALID_IPV4_PAYLOAD" > "$TMPDIR/valid-set-v4.json"
+assert_json "$TMPDIR/valid-set-v4.json" '.result == "saved"'
+echo "Sequential static address saves: PASS"
+
+api_request GET "/api/interfaces/assignment/get_item/$IFACE" \
+    > "$TMPDIR/valid-get.json"
+assert_json "$TMPDIR/valid-get.json" \
+    ".interface.ipaddr == \"$TEST_IPV4\" and .interface.subnet == \"$TEST_PREFIX4\""
+assert_json "$TMPDIR/valid-get.json" \
+    ".interface.ipaddrv6 == \"$TEST_IPV6\" and .interface.subnetv6 == \"$TEST_PREFIX6\""
+echo "API read-back: PASS"
+
+api_request POST '/api/interfaces/assignment/reconfigure' \
+    "$(jq -nc '{}')" > "$TMPDIR/apply.json"
+assert_json "$TMPDIR/apply.json" '.status == "ok"'
+sleep 2
+echo "Interface reconfigure: PASS"
+
+config_value() {
+    php -r '$xml=simplexml_load_file("/conf/config.xml"); echo (string)$xml->interfaces->{$argv[1]}->{$argv[2]};' \
+        "$IFACE" "$1"
+}
+
+[ "$(config_value ipaddr)" = "$TEST_IPV4" ]
+[ "$(config_value subnet)" = "$TEST_PREFIX4" ]
+[ "$(config_value ipaddrv6)" = "$TEST_IPV6" ]
+[ "$(config_value subnetv6)" = "$TEST_PREFIX6" ]
+echo "config.xml persistence: PASS"
+
+ifconfig "$DEVICE" | grep -F "inet $TEST_IPV4 " >/dev/null
+ifconfig "$DEVICE" | grep -F "inet6 $TEST_IPV6 " >/dev/null
+echo "Runtime interface state: PASS"
+echo "All interface static-addressing API tests passed"

--- a/src/opnsense/mvc/tests/app/models/OPNsense/Interfaces/NetworkInterfaceTest.php
+++ b/src/opnsense/mvc/tests/app/models/OPNsense/Interfaces/NetworkInterfaceTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace tests\OPNsense\Interfaces;
+
+use OPNsense\Core\AppConfig;
+use OPNsense\Core\Config;
+use OPNsense\Interfaces\NetworkInterface;
+
+class NetworkInterfaceTest extends \PHPUnit\Framework\TestCase
+{
+    private string $configDir;
+
+    protected function setUp(): void
+    {
+        $this->configDir = sys_get_temp_dir() . '/network-interface-' . uniqid();
+        mkdir($this->configDir, 0700, true);
+        copy(__DIR__ . '/NetworkInterfaceTest/config.xml', $this->configDir . '/config.xml');
+        (new AppConfig())->update('application.configDir', $this->configDir);
+        Config::getInstance()->forceReload();
+    }
+
+    protected function tearDown(): void
+    {
+        @unlink($this->configDir . '/config.xml');
+        @rmdir($this->configDir);
+    }
+
+    public function testStaticAndDynamicAddressesAreLoadedSafely(): void
+    {
+        $model = new NetworkInterface();
+        $data = $model->interface->getNodeContent();
+        $this->assertSame('192.0.2.2', $data['wan']['ipaddr']);
+        $this->assertSame('24', $data['wan']['subnet']);
+        $this->assertSame('WAN_GW', $data['wan']['gateway']);
+    }
+
+    public function testAddressRequiresPrefix(): void
+    {
+        $model = new NetworkInterface();
+        $model->getNodeByReference('interface.wan')->ipaddrv6->setValue('2001:db8::2');
+        $messages = $model->performValidation();
+        $this->assertNotEmpty($messages->getMessages());
+    }
+
+    public function testPrefixRangeIsValidated(): void
+    {
+        $model = new NetworkInterface();
+        $model->getNodeByReference('interface.wan')->subnet->setValue('33');
+        $messages = $model->performValidation();
+        $this->assertNotEmpty($messages->getMessages());
+    }
+
+    public function testGatewayMustExistAndMatchInterfaceFamily(): void
+    {
+        $model = new NetworkInterface();
+        $model->getNodeByReference('interface.wan')->gateway->setValue('WAN6_GW');
+        $messages = $model->performValidation();
+        $this->assertNotEmpty($messages->getMessages());
+    }
+
+    public function testDynamicConfigurationIsPreservedWhenDescriptionChanges(): void
+    {
+        $config = Config::getInstance()->object();
+        $config->interfaces->wan->ipaddr = 'dhcp';
+        $config->interfaces->wan->ipaddrv6 = 'slaac';
+        $model = new NetworkInterface();
+        $model->getNodeByReference('interface.wan')->descr->setValue('Updated WAN');
+        $this->assertTrue($model->serializeToConfig());
+        $this->assertSame('dhcp', (string)$config->interfaces->wan->ipaddr);
+        $this->assertSame('slaac', (string)$config->interfaces->wan->ipaddrv6);
+    }
+
+    public function testStaticIpv6IsSerialized(): void
+    {
+        $model = new NetworkInterface();
+        $model->getNodeByReference('interface.wan')->ipaddrv6->setValue('2001:db8::2');
+        $model->getNodeByReference('interface.wan')->subnetv6->setValue('64');
+        $model->getNodeByReference('interface.wan')->gatewayv6->setValue('WAN6_GW');
+        $this->assertEmpty($model->performValidation()->getMessages());
+        $this->assertTrue($model->serializeToConfig());
+        $config = Config::getInstance()->object();
+        $this->assertSame('2001:db8::2', (string)$config->interfaces->wan->ipaddrv6);
+        $this->assertSame('64', (string)$config->interfaces->wan->subnetv6);
+        $this->assertSame('WAN6_GW', (string)$config->interfaces->wan->gatewayv6);
+    }
+}

--- a/src/opnsense/mvc/tests/app/models/OPNsense/Interfaces/NetworkInterfaceTest.php
+++ b/src/opnsense/mvc/tests/app/models/OPNsense/Interfaces/NetworkInterfaceTest.php
@@ -9,11 +9,18 @@ use OPNsense\Interfaces\NetworkInterface;
 class NetworkInterfaceTest extends \PHPUnit\Framework\TestCase
 {
     private string $configDir;
+    private string $todoFile;
+    private ?string $defaultTodoBackup = null;
 
     protected function setUp(): void
     {
         $this->configDir = sys_get_temp_dir() . '/network-interface-' . uniqid();
+        $this->todoFile = $this->configDir . '/interfaces.todo';
         mkdir($this->configDir, 0700, true);
+        if (is_file('/tmp/.interfaces.todo')) {
+            $this->defaultTodoBackup = $this->configDir . '/default-interfaces.todo';
+            rename('/tmp/.interfaces.todo', $this->defaultTodoBackup);
+        }
         copy(__DIR__ . '/NetworkInterfaceTest/config.xml', $this->configDir . '/config.xml');
         (new AppConfig())->update('application.configDir', $this->configDir);
         Config::getInstance()->forceReload();
@@ -21,13 +28,24 @@ class NetworkInterfaceTest extends \PHPUnit\Framework\TestCase
 
     protected function tearDown(): void
     {
+        @unlink($this->todoFile);
         @unlink($this->configDir . '/config.xml');
+        if ($this->defaultTodoBackup !== null && is_file($this->defaultTodoBackup)) {
+            rename($this->defaultTodoBackup, '/tmp/.interfaces.todo');
+        }
         @rmdir($this->configDir);
+    }
+
+    private function newModel(): NetworkInterface
+    {
+        $model = new NetworkInterface();
+        $model->todo_file = $this->todoFile;
+        return $model;
     }
 
     public function testStaticAndDynamicAddressesAreLoadedSafely(): void
     {
-        $model = new NetworkInterface();
+        $model = $this->newModel();
         $data = $model->interface->getNodeContent();
         $this->assertSame('192.0.2.2', $data['wan']['ipaddr']);
         $this->assertSame('24', $data['wan']['subnet']);
@@ -36,7 +54,7 @@ class NetworkInterfaceTest extends \PHPUnit\Framework\TestCase
 
     public function testAddressRequiresPrefix(): void
     {
-        $model = new NetworkInterface();
+        $model = $this->newModel();
         $model->getNodeByReference('interface.wan')->ipaddrv6->setValue('2001:db8::2');
         $messages = $model->performValidation();
         $this->assertNotEmpty($messages->getMessages());
@@ -44,7 +62,7 @@ class NetworkInterfaceTest extends \PHPUnit\Framework\TestCase
 
     public function testPrefixRangeIsValidated(): void
     {
-        $model = new NetworkInterface();
+        $model = $this->newModel();
         $model->getNodeByReference('interface.wan')->subnet->setValue('33');
         $messages = $model->performValidation();
         $this->assertNotEmpty($messages->getMessages());
@@ -52,7 +70,7 @@ class NetworkInterfaceTest extends \PHPUnit\Framework\TestCase
 
     public function testGatewayMustExistAndMatchInterfaceFamily(): void
     {
-        $model = new NetworkInterface();
+        $model = $this->newModel();
         $model->getNodeByReference('interface.wan')->gateway->setValue('WAN6_GW');
         $messages = $model->performValidation();
         $this->assertNotEmpty($messages->getMessages());
@@ -63,7 +81,7 @@ class NetworkInterfaceTest extends \PHPUnit\Framework\TestCase
         $config = Config::getInstance()->object();
         $config->interfaces->wan->ipaddr = 'dhcp';
         $config->interfaces->wan->ipaddrv6 = 'slaac';
-        $model = new NetworkInterface();
+        $model = $this->newModel();
         $model->getNodeByReference('interface.wan')->descr->setValue('Updated WAN');
         $this->assertTrue($model->serializeToConfig());
         $this->assertSame('dhcp', (string)$config->interfaces->wan->ipaddr);
@@ -72,7 +90,7 @@ class NetworkInterfaceTest extends \PHPUnit\Framework\TestCase
 
     public function testStaticIpv6IsSerialized(): void
     {
-        $model = new NetworkInterface();
+        $model = $this->newModel();
         $model->getNodeByReference('interface.wan')->ipaddrv6->setValue('2001:db8::2');
         $model->getNodeByReference('interface.wan')->subnetv6->setValue('64');
         $model->getNodeByReference('interface.wan')->gatewayv6->setValue('WAN6_GW');
@@ -82,5 +100,44 @@ class NetworkInterfaceTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('2001:db8::2', (string)$config->interfaces->wan->ipaddrv6);
         $this->assertSame('64', (string)$config->interfaces->wan->subnetv6);
         $this->assertSame('WAN6_GW', (string)$config->interfaces->wan->gatewayv6);
+    }
+
+    public function testAddressChangeSchedulesReconfigure(): void
+    {
+        $model = $this->newModel();
+        $model->getNodeByReference('interface.wan')->ipaddr->setValue('192.0.2.3');
+        $this->assertTrue($model->serializeToConfig());
+        $todo = $model->get_if_todo();
+        $this->assertSame('reconfigure', $todo['wan']['pending_action']);
+        $this->assertSame([4], $todo['wan']['pending_families']);
+    }
+
+    public function testRelinkTakesPrecedenceOverAddressReconfigure(): void
+    {
+        $model = $this->newModel();
+        $node = $model->getNodeByReference('interface.wan');
+        $node->ipaddr->setValue('192.0.2.3');
+        $node->if->setValue('em9');
+        $this->assertTrue($model->serializeToConfig());
+        $todo = $model->get_if_todo();
+        $this->assertSame('relink', $todo['wan']['pending_action']);
+        $this->assertSame('em9', $todo['wan']['pending_if']);
+        $this->assertSame([4], $todo['wan']['pending_families']);
+    }
+
+    public function testAddressFamiliesAccumulateUntilApply(): void
+    {
+        $model = $this->newModel();
+        $node = $model->getNodeByReference('interface.wan');
+        $node->ipaddrv6->setValue('2001:db8::2');
+        $node->subnetv6->setValue('64');
+        $this->assertTrue($model->serializeToConfig());
+
+        $model = $this->newModel();
+        $model->getNodeByReference('interface.wan')->ipaddr->setValue('192.0.2.3');
+        $this->assertTrue($model->serializeToConfig());
+        $todo = $model->get_if_todo();
+        $this->assertSame('reconfigure', $todo['wan']['pending_action']);
+        $this->assertSame([6, 4], $todo['wan']['pending_families']);
     }
 }

--- a/src/opnsense/mvc/tests/app/models/OPNsense/Interfaces/NetworkInterfaceTest/config.xml
+++ b/src/opnsense/mvc/tests/app/models/OPNsense/Interfaces/NetworkInterfaceTest/config.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<opnsense>
+  <interfaces>
+    <wan>
+      <if>em0</if>
+      <descr>WAN</descr>
+      <ipaddr>192.0.2.2</ipaddr>
+      <subnet>24</subnet>
+      <gateway>WAN_GW</gateway>
+    </wan>
+  </interfaces>
+  <OPNsense>
+    <Gateways>
+      <gateway_item uuid="11111111-1111-1111-1111-111111111111">
+        <name>WAN_GW</name>
+        <interface>wan</interface>
+        <ipprotocol>inet</ipprotocol>
+        <gateway>192.0.2.1</gateway>
+      </gateway_item>
+      <gateway_item uuid="22222222-2222-2222-2222-222222222222">
+        <name>WAN6_GW</name>
+        <interface>wan</interface>
+        <ipprotocol>inet6</ipprotocol>
+        <gateway>2001:db8::1</gateway>
+      </gateway_item>
+    </Gateways>
+  </OPNsense>
+</opnsense>

--- a/src/opnsense/scripts/interfaces/apply_pending_if_changes.php
+++ b/src/opnsense/scripts/interfaces/apply_pending_if_changes.php
@@ -45,16 +45,25 @@ if (is_array($config['interfaces'])) {
             continue;
         }
         $pending_act = $todos[$id]['pending_action'] ?? '';
+        foreach (array_unique($todos[$id]['pending_families'] ?? []) as $family) {
+            if (!in_array($family, [4, 6])) {
+                continue;
+            }
+            $device = $family == 6 ? get_real_interface($id, 'inet6') : $ifcfg['if'];
+            interfaces_addresses_flush($device, $family);
+        }
         if (in_array($pending_act, ['delete', 'relink'])) {
             interface_reset($id);
-            if ($pending_act == 'relink') {
-                $to_configure[] = $id;
-            }
+        }
+        if (in_array($pending_act, ['relink', 'reconfigure'])) {
+            $to_configure[] = $id;
         }
     }
 
     foreach ($to_configure as $ifname) {
-        $config['interfaces'][$ifname]['if'] = $todos[$ifname]['pending_if'];
+        if (($todos[$ifname]['pending_action'] ?? '') == 'relink') {
+            $config['interfaces'][$ifname]['if'] = $todos[$ifname]['pending_if'];
+        }
         if (isset($config['interfaces'][$ifname]['wireless'])) {
             interface_sync_wireless_clones($config['interfaces'][$ifname], false);
         }


### PR DESCRIPTION
Adds static IPv4/IPv6 assignment fields, validation, live apply, and regression tests. Tests: 9 tests / 25 assertions targeted; 316 tests / 756 assertions full suite; HTTP API test on LAN with rollback.