### PR TITLE
interfaces: allow VLAN names without leading zero

### DIFF
--- a/src/opnsense/mvc/app/controllers/OPNsense/Interfaces/forms/dialogVlan.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Interfaces/forms/dialogVlan.xml
@@ -6,7 +6,7 @@
         <help>
           Leave empty to generate a device name. Custom names are possible, but only if the
           start of the name matches the required prefix and contains numeric characters or
-          dots, e.g. "vlan0.1.2" or "qinq0.3.4".
+          dots, e.g. "vlan100", "vlan0.1.2", or "qinq0.3.4".
         </help>
     </field>
     <field>

--- a/src/opnsense/mvc/app/models/OPNsense/Interfaces/Vlan.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Interfaces/Vlan.php
@@ -68,13 +68,14 @@ class Vlan extends BaseModel
                                 sprintf(gettext('The device name prefix "%s" is required.'), (string)$prefix),
                                 $key
                             ));
-                        } elseif (!preg_match("/^{$prefix}0([0-9\.]){1,10}$/", (string)$node)) {
+                        } elseif (!preg_match("/^{$prefix}[0-9][0-9\.]{0,10}$/", (string)$node)) {
                             $messages->appendMessage(new Message(
                                 sprintf(
                                     gettext(
-                                        'Only a maximum of 15 characters is allowed starting with "%s0" combined with ' .
-                                        'numeric characters and dots, e.g. "%s0.1.104".'
+                                        'Only a maximum of 15 characters is allowed starting with "%s" followed by ' .
+                                        'numeric characters and dots, e.g. "%s100" or "%s0.1.104".'
                                     ),
+                                    $prefix,
                                     $prefix,
                                     $prefix
                                 ),

--- a/src/opnsense/mvc/tests/app/models/OPNsense/Interfaces/VlanTest.php
+++ b/src/opnsense/mvc/tests/app/models/OPNsense/Interfaces/VlanTest.php
@@ -1,0 +1,99 @@
+<?php
+
+/*
+ * Copyright (C) 2026 Biptec
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace tests\OPNsense\Interfaces;
+
+use OPNsense\Core\AppConfig;
+use OPNsense\Core\Config;
+use OPNsense\Interfaces\Vlan;
+
+class VlanTest extends \PHPUnit\Framework\TestCase
+{
+    private function validateDeviceName(string $parent, string $name): array
+    {
+        (new AppConfig())->update('application.configDir', __DIR__ . '/VlanTest');
+        Config::getInstance()->forceReload();
+
+        $model = new Vlan();
+        $vlan = $model->vlan->Add();
+        $vlan->if = $parent;
+        $vlan->tag = 100;
+        $vlan->pcp = 0;
+        $vlan->vlanif = $name;
+
+        $result = [];
+        foreach ($model->performValidation(true) as $message) {
+            if (str_ends_with($message->getField(), '.vlanif')) {
+                $result[] = $message->getMessage();
+            }
+        }
+        return $result;
+    }
+
+    public function validDeviceNamesProvider(): array
+    {
+        return [
+            ['em0', 'vlan0'],
+            ['em0', 'vlan5'],
+            ['em0', 'vlan55'],
+            ['em0', 'vlan100'],
+            ['em0', 'vlan0.1.104'],
+            ['em0', 'vlan12345678901'],
+            ['vlan100', 'qinq5'],
+            ['vlan100', 'qinq0.3.4'],
+        ];
+    }
+
+    /**
+     * @dataProvider validDeviceNamesProvider
+     */
+    public function testValidDeviceNames(string $parent, string $name): void
+    {
+        $this->assertSame([], $this->validateDeviceName($parent, $name));
+    }
+
+    public function invalidDeviceNamesProvider(): array
+    {
+        return [
+            ['em0', 'vlan'],
+            ['em0', 'vlan.100'],
+            ['em0', 'vlan-name'],
+            ['em0', 'vlan123456789012'],
+            ['em0', 'qinq100'],
+            ['vlan100', 'vlan200'],
+        ];
+    }
+
+    /**
+     * @dataProvider invalidDeviceNamesProvider
+     */
+    public function testInvalidDeviceNames(string $parent, string $name): void
+    {
+        $this->assertNotSame([], $this->validateDeviceName($parent, $name));
+    }
+}

--- a/src/opnsense/mvc/tests/app/models/OPNsense/Interfaces/VlanTest/config.xml
+++ b/src/opnsense/mvc/tests/app/models/OPNsense/Interfaces/VlanTest/config.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<opnsense>
+  <interfaces>
+    <wan>
+      <if>em0</if>
+      <descr>WAN</descr>
+      <enable>1</enable>
+    </wan>
+  </interfaces>
+  <vlans/>
+</opnsense>


### PR DESCRIPTION
Allows vlan5, vlan55, vlan100 and equivalent QinQ names while preserving the 15-character limit. Adds positive and negative regression tests. Tests: 14 tests / 14 assertions targeted; 321 tests / 745 assertions full suite.