### PR TITLE
auth: add API key management CLI

### DIFF
--- a/plist
+++ b/plist
@@ -517,6 +517,7 @@
 /usr/local/opnsense/mvc/app/controllers/OPNsense/Wireguard/forms/dialogEditWireguardServer.xml
 /usr/local/opnsense/mvc/app/controllers/OPNsense/Wireguard/forms/general.xml
 /usr/local/opnsense/mvc/app/library/OPNsense/Auth/API.php
+/usr/local/opnsense/mvc/app/library/OPNsense/Auth/ApiKeyCommand.php
 /usr/local/opnsense/mvc/app/library/OPNsense/Auth/AuthenticationFactory.php
 /usr/local/opnsense/mvc/app/library/OPNsense/Auth/Base.php
 /usr/local/opnsense/mvc/app/library/OPNsense/Auth/IAuthConnector.php
@@ -2531,6 +2532,7 @@
 /usr/local/sbin/carp_service_status
 /usr/local/sbin/configctl
 /usr/local/sbin/ifctl
+/usr/local/sbin/opnsense-apikey
 /usr/local/sbin/opnsense-beep
 /usr/local/sbin/opnsense-crypt
 /usr/local/sbin/opnsense-importer

--- a/src/opnsense/mvc/app/library/OPNsense/Auth/ApiKeyCommand.php
+++ b/src/opnsense/mvc/app/library/OPNsense/Auth/ApiKeyCommand.php
@@ -1,0 +1,141 @@
+<?php
+
+/*
+ * Copyright (C) 2026 Biptec
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\Auth;
+
+class ApiKeyCommand
+{
+    private $api;
+
+    public function __construct($api = null)
+    {
+        $this->api = $api ?? new API();
+    }
+
+    public function run(array $argv, callable $stdout, callable $stderr): int
+    {
+        $options = $this->parseArguments($argv);
+        if (!empty($options['error'])) {
+            $stderr($options['error'] . "\n");
+            $this->usage($stderr);
+            return 1;
+        }
+        if ($options['help']) {
+            $this->usage($stdout);
+            return 0;
+        }
+
+        $args = $options['args'];
+        if (count($args) === 0) {
+            $this->usage($stderr);
+            return 1;
+        }
+
+        switch ($args[0]) {
+            case 'create':
+                if (count($args) !== 1) {
+                    $this->usage($stderr);
+                    return 1;
+                }
+                $data = $this->api->createKey($options['username']);
+                if ($data === false) {
+                    $stderr(sprintf('User "%s" was not found.', $options['username']) . "\n");
+                    return 1;
+                }
+                if ($options['json']) {
+                    $stdout(json_encode($data, JSON_UNESCAPED_SLASHES) . "\n");
+                } else {
+                    $stdout(sprintf("key=%s\nsecret=%s\n", $data['key'], $data['secret']));
+                }
+                return 0;
+
+            case 'delete':
+                if (count($args) !== 2) {
+                    $this->usage($stderr);
+                    return 1;
+                }
+                if (!$this->api->dropKey($options['username'], $args[1])) {
+                    $stderr(sprintf('API key was not found for user "%s".', $options['username']) . "\n");
+                    return 1;
+                }
+                return 0;
+
+            default:
+                $this->usage($stderr);
+                return 1;
+        }
+    }
+
+    private function parseArguments(array $argv): array
+    {
+        $result = [
+            'username' => 'root',
+            'json' => false,
+            'help' => false,
+            'args' => [],
+            'error' => '',
+        ];
+
+        for ($i = 1; $i < count($argv); $i++) {
+            $arg = $argv[$i];
+            if ($arg === '--') {
+                $result['args'] = array_slice($argv, $i + 1);
+                break;
+            } elseif ($arg === '-h' || $arg === '--help') {
+                $result['help'] = true;
+            } elseif ($arg === '-j' || $arg === '--json') {
+                $result['json'] = true;
+            } elseif ($arg === '-u' || $arg === '--user') {
+                if (!isset($argv[$i + 1]) || $argv[$i + 1] === '') {
+                    $result['error'] = 'A username is required.';
+                    break;
+                }
+                $result['username'] = $argv[++$i];
+            } elseif (str_starts_with($arg, '--user=')) {
+                $result['username'] = substr($arg, strlen('--user='));
+                if ($result['username'] === '') {
+                    $result['error'] = 'A username is required.';
+                    break;
+                }
+            } elseif (str_starts_with($arg, '-')) {
+                $result['error'] = sprintf('Unknown option "%s".', $arg);
+                break;
+            } else {
+                $result['args'] = array_slice($argv, $i);
+                break;
+            }
+        }
+        return $result;
+    }
+
+    private function usage(callable $output): void
+    {
+        $output("Usage:\n");
+        $output("  opnsense-apikey [-u username] [-j|--json] create\n");
+        $output("  opnsense-apikey [-u username] delete apikey\n");
+    }
+}

--- a/src/opnsense/mvc/tests/app/library/OPNsense/Auth/ApiKeyCommandTest.php
+++ b/src/opnsense/mvc/tests/app/library/OPNsense/Auth/ApiKeyCommandTest.php
@@ -1,0 +1,155 @@
+<?php
+
+/*
+ * Copyright (C) 2026 Biptec
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace tests\OPNsense\Auth;
+
+use OPNsense\Auth\ApiKeyCommand;
+
+class ApiKeyStub
+{
+    public $createResult = ['key' => 'test-key', 'secret' => 'test-secret'];
+    public $deleteResult = true;
+    public $createdFor = null;
+    public $deletedFor = null;
+
+    public function createKey($username)
+    {
+        $this->createdFor = $username;
+        return $this->createResult;
+    }
+
+    public function dropKey($username, $key)
+    {
+        $this->deletedFor = [$username, $key];
+        return $this->deleteResult;
+    }
+}
+
+class ApiKeyCommandTest extends \PHPUnit\Framework\TestCase
+{
+    private function runCommand(array $argv, ApiKeyStub $api): array
+    {
+        $stdout = '';
+        $stderr = '';
+        $status = (new ApiKeyCommand($api))->run(
+            $argv,
+            function ($message) use (&$stdout) {
+                $stdout .= $message;
+            },
+            function ($message) use (&$stderr) {
+                $stderr .= $message;
+            }
+        );
+        return [$status, $stdout, $stderr];
+    }
+
+    public function testHelp(): void
+    {
+        [$status, $stdout, $stderr] = $this->runCommand(['opnsense-apikey', '--help'], new ApiKeyStub());
+        $this->assertSame(0, $status);
+        $this->assertStringStartsWith("Usage:\n", $stdout);
+        $this->assertSame('', $stderr);
+    }
+
+    public function testCreateForDefaultUser(): void
+    {
+        $api = new ApiKeyStub();
+        [$status, $stdout, $stderr] = $this->runCommand(['opnsense-apikey', 'create'], $api);
+        $this->assertSame(0, $status);
+        $this->assertSame("key=test-key\nsecret=test-secret\n", $stdout);
+        $this->assertSame('', $stderr);
+        $this->assertSame('root', $api->createdFor);
+    }
+
+    public function testCreateJsonForSelectedUser(): void
+    {
+        $api = new ApiKeyStub();
+        [$status, $stdout] = $this->runCommand(
+            ['opnsense-apikey', '--user=automation', '--json', 'create'],
+            $api
+        );
+        $this->assertSame(0, $status);
+        $this->assertSame("{\"key\":\"test-key\",\"secret\":\"test-secret\"}\n", $stdout);
+        $this->assertSame('automation', $api->createdFor);
+    }
+
+    public function testCreateForMissingUser(): void
+    {
+        $api = new ApiKeyStub();
+        $api->createResult = false;
+        [$status, $stdout, $stderr] = $this->runCommand(['opnsense-apikey', '-u', 'missing', 'create'], $api);
+        $this->assertSame(1, $status);
+        $this->assertSame('', $stdout);
+        $this->assertStringContainsString('was not found', $stderr);
+    }
+
+    public function testDelete(): void
+    {
+        $api = new ApiKeyStub();
+        [$status, $stdout, $stderr] = $this->runCommand(
+            ['opnsense-apikey', '--user', 'automation', 'delete', 'test-key'],
+            $api
+        );
+        $this->assertSame(0, $status);
+        $this->assertSame('', $stdout);
+        $this->assertSame('', $stderr);
+        $this->assertSame(['automation', 'test-key'], $api->deletedFor);
+    }
+
+    public function testDeleteMissingKey(): void
+    {
+        $api = new ApiKeyStub();
+        $api->deleteResult = false;
+        [$status, $stdout, $stderr] = $this->runCommand(['opnsense-apikey', 'delete', 'missing'], $api);
+        $this->assertSame(1, $status);
+        $this->assertSame('', $stdout);
+        $this->assertStringContainsString('API key was not found', $stderr);
+    }
+
+    public function invalidArgumentsProvider(): array
+    {
+        return [
+            [['opnsense-apikey']],
+            [['opnsense-apikey', '--unknown']],
+            [['opnsense-apikey', '--user']],
+            [['opnsense-apikey', 'create', 'extra']],
+            [['opnsense-apikey', 'delete']],
+            [['opnsense-apikey', 'unknown-command']],
+        ];
+    }
+
+    /**
+     * @dataProvider invalidArgumentsProvider
+     */
+    public function testInvalidArguments(array $argv): void
+    {
+        [$status, $stdout, $stderr] = $this->runCommand($argv, new ApiKeyStub());
+        $this->assertSame(1, $status);
+        $this->assertSame('', $stdout);
+        $this->assertStringContainsString('Usage:', $stderr);
+    }
+}

--- a/src/sbin/opnsense-apikey
+++ b/src/sbin/opnsense-apikey
@@ -1,0 +1,40 @@
+#!/usr/local/bin/php
+<?php
+
+/*
+ * Copyright (C) 2026 Biptec
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+require_once 'script/load_phalcon.php';
+
+$command = new OPNsense\Auth\ApiKeyCommand();
+exit($command->run(
+    $argv,
+    function ($message) {
+        fwrite(STDOUT, $message);
+    },
+    function ($message) {
+        fwrite(STDERR, $message);
+    }
+));


### PR DESCRIPTION
Adds opnsense-apikey for creating and deleting user API keys. Supports user selection, plain or JSON output, explicit error handling, a testable command class, and launcher regression tests. Tests: 12 tests / 38 assertions targeted; 319 tests / 769 assertions full suite; launcher help and invalid-command checks passed.