### PR TITLE
interfaces: expose basic assignment settings

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/Interfaces/NetworkInterface.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Interfaces/NetworkInterface.php
@@ -37,6 +37,10 @@ class NetworkInterface extends BaseModel
 {
     var $todo_file = '/tmp/.interfaces.todo';
 
+    private const RECONFIGURE_FIELDS = ['enable', 'spoofmac', 'promisc', 'mtu'];
+    private const FILTER_FIELDS = ['blockpriv', 'blockbogons', 'gateway_interface', 'mss'];
+    private const BOOLEAN_FIELDS = ['enable', 'blockpriv', 'blockbogons', 'gateway_interface', 'promisc'];
+
     /**
      * @param array $payload data to store
      */
@@ -45,9 +49,10 @@ class NetworkInterface extends BaseModel
         $fobj = new FileObject($this->todo_file, 'a+', 0600, LOCK_EX);
         $data = $fobj->readJson() ?? [];
         $current_action = $data[$id]['pending_action'] ?? '';
+        $next_action = $payload['pending_action'] ?? '';
         if (
-            ($payload['pending_action'] ?? '') == 'reconfigure' &&
-            in_array($current_action, ['delete', 'relink'])
+            (in_array($current_action, ['delete', 'relink']) && in_array($next_action, ['filter', 'reconfigure'])) ||
+            ($current_action == 'reconfigure' && $next_action == 'filter')
         ) {
             unset($payload['pending_action']);
         }
@@ -113,6 +118,14 @@ class NetworkInterface extends BaseModel
             $node->descr = (string)$intf->descr;
             $node->identifier = $key;
             $node->lock = empty((string)$intf->lock) ? '0' : '1';
+            foreach (array_merge(self::RECONFIGURE_FIELDS, self::FILTER_FIELDS) as $field) {
+                if (in_array($field, self::BOOLEAN_FIELDS)) {
+                    $node->$field = empty((string)$intf->$field) ? '0' : '1';
+                } else {
+                    $node->$field = (string)$intf->$field;
+                }
+                $node->$field->markUnchanged();
+            }
             foreach (['' => FILTER_FLAG_IPV4, 'v6' => FILTER_FLAG_IPV6] as $suffix => $filter_flag) {
                 $addr_field = 'ipaddr' . $suffix;
                 $subnet_field = 'subnet' . $suffix;
@@ -152,6 +165,32 @@ class NetworkInterface extends BaseModel
             } else {
                 $intf->descr = $interfaces[$key]['descr'];
                 $intf->lock = $interfaces[$key]['lock'];
+                $pending_action = '';
+                foreach (array_merge(self::RECONFIGURE_FIELDS, self::FILTER_FIELDS) as $field) {
+                    if (!$model_interfaces[$key]->$field->isFieldChanged()) {
+                        continue;
+                    }
+                    $value = $interfaces[$key][$field];
+                    if (in_array($field, self::BOOLEAN_FIELDS)) {
+                        if ($value == '1') {
+                            $intf->$field = '1';
+                        } else {
+                            unset($intf->$field);
+                        }
+                    } elseif ($value === '') {
+                        unset($intf->$field);
+                    } else {
+                        $intf->$field = $value;
+                    }
+                    if (in_array($field, self::RECONFIGURE_FIELDS)) {
+                        $pending_action = 'reconfigure';
+                    } elseif ($pending_action === '') {
+                        $pending_action = 'filter';
+                    }
+                }
+                if ($pending_action !== '') {
+                    $this->store_if_todo($key, ['pending_action' => $pending_action]);
+                }
                 $changed_families = [];
                 foreach (['ipaddr', 'subnet', 'gateway', 'ipaddrv6', 'subnetv6', 'gatewayv6'] as $field) {
                     if ($model_interfaces[$key]->$field->isFieldChanged()) {
@@ -191,15 +230,24 @@ class NetworkInterface extends BaseModel
 
         foreach ($interfaces as $key => $intf) {
             if (!isset(Config::getInstance()->object()->interfaces->$key)) {
-                $newif = Config::getInstance()->object()->interfaces->addChild('opt' . $next_if);
+                $new_key = 'opt' . $next_if;
+                $newif = Config::getInstance()->object()->interfaces->addChild($new_key);
                 $newif->if = $intf['if'];
                 $newif->descr = $intf['descr'];
                 $newif->lock = $intf['lock'];
+                foreach (array_merge(self::RECONFIGURE_FIELDS, self::FILTER_FIELDS) as $field) {
+                    $value = $intf[$field];
+                    if ((in_array($field, self::BOOLEAN_FIELDS) && $value == '1') ||
+                        (!in_array($field, self::BOOLEAN_FIELDS) && $value !== '')) {
+                        $newif->$field = $value;
+                    }
+                }
                 foreach (['ipaddr', 'subnet', 'gateway', 'ipaddrv6', 'subnetv6', 'gatewayv6'] as $field) {
                     if ($intf[$field] !== '') {
                         $newif->$field = $intf[$field];
                     }
                 }
+                $this->store_if_todo($new_key, ['pending_action' => 'reconfigure']);
                 $next_if++;
             }
         }

--- a/src/opnsense/mvc/app/models/OPNsense/Interfaces/NetworkInterface.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Interfaces/NetworkInterface.xml
@@ -1,6 +1,6 @@
 <model>
     <mount>:memory:</mount>
-    <version>0.0.2</version>
+    <version>0.0.3</version>
     <description>Interface assignments</description>
     <items>
         <interface type="ArrayField">
@@ -22,6 +22,35 @@
                 <Default>1</Default>
                 <Required>Y</Required>
             </lock>
+            <enable type="BooleanField">
+                <Default>0</Default>
+                <Required>Y</Required>
+            </enable>
+            <blockpriv type="BooleanField">
+                <Default>0</Default>
+                <Required>Y</Required>
+            </blockpriv>
+            <blockbogons type="BooleanField">
+                <Default>0</Default>
+                <Required>Y</Required>
+            </blockbogons>
+            <gateway_interface type="BooleanField">
+                <Default>0</Default>
+                <Required>Y</Required>
+            </gateway_interface>
+            <promisc type="BooleanField">
+                <Default>0</Default>
+                <Required>Y</Required>
+            </promisc>
+            <spoofmac type="MacAddressField"/>
+            <mtu type="IntegerField">
+                <MinimumValue>576</MinimumValue>
+                <MaximumValue>65535</MaximumValue>
+            </mtu>
+            <mss type="IntegerField">
+                <MinimumValue>576</MinimumValue>
+                <MaximumValue>65535</MaximumValue>
+            </mss>
             <ipaddr type="NetworkField">
                 <AddressFamily>ipv4</AddressFamily>
                 <NetMaskAllowed>N</NetMaskAllowed>

--- a/src/opnsense/mvc/tests/api/interfaces_assignment_basic_settings.sh
+++ b/src/opnsense/mvc/tests/api/interfaces_assignment_basic_settings.sh
@@ -1,0 +1,126 @@
+#!/bin/sh
+set -eu
+
+: "${OPNSENSE_API_KEY:?Set OPNSENSE_API_KEY}"
+: "${OPNSENSE_API_SECRET:?Set OPNSENSE_API_SECRET}"
+
+BASE_URL=${OPNSENSE_URL:-http://127.0.0.1}
+IFACE=${OPNSENSE_TEST_INTERFACE:-lan}
+TEST_MTU=${OPNSENSE_TEST_MTU:-1400}
+TMPDIR=$(mktemp -d /tmp/interfaces-basic-api-test.XXXXXX)
+ORIGINAL="$TMPDIR/original.json"
+
+api_request() {
+    method=$1
+    path=$2
+    data=${3-}
+    if [ "$method" = GET ]; then
+        curl -fsS -u "$OPNSENSE_API_KEY:$OPNSENSE_API_SECRET" "$BASE_URL$path"
+    else
+        curl -fsS -u "$OPNSENSE_API_KEY:$OPNSENSE_API_SECRET" \
+            -H 'Content-Type: application/json' -X "$method" \
+            -d "$data" "$BASE_URL$path"
+    fi
+}
+
+assert_json() {
+    file=$1
+    expression=$2
+    jq -e "$expression" "$file" >/dev/null || {
+        echo "Assertion failed: $expression" >&2
+        cat "$file" >&2
+        exit 1
+    }
+}
+api_request GET "/api/interfaces/assignment/get_item/$IFACE" > "$ORIGINAL"
+DEVICE=$(jq -r '.interface.if | to_entries[] | select(.value.selected == 1) | .key' "$ORIGINAL")
+[ -n "$DEVICE" ] || { echo "Assigned device not found" >&2; exit 1; }
+ORIGINAL_RUNTIME_MTU=$(ifconfig "$DEVICE" | awk 'NR == 1 {for (i=1; i<=NF; i++) if ($i == "mtu") print $(i+1)}')
+
+RESTORE_PAYLOAD=$(jq -c '{interface: {
+    enable: .interface.enable,
+    blockpriv: .interface.blockpriv,
+    blockbogons: .interface.blockbogons,
+    gateway_interface: .interface.gateway_interface,
+    promisc: .interface.promisc,
+    spoofmac: .interface.spoofmac,
+    mtu: .interface.mtu,
+    mss: .interface.mss
+}}' "$ORIGINAL")
+
+cleanup() {
+    status=$?
+    trap - EXIT HUP INT TERM
+    set +e
+    api_request POST "/api/interfaces/assignment/set_item/$IFACE" \
+        "$RESTORE_PAYLOAD" > "$TMPDIR/restore-set.json"
+    api_request POST '/api/interfaces/assignment/reconfigure' '{}' \
+        > "$TMPDIR/restore-apply.json"
+    if [ -n "$ORIGINAL_RUNTIME_MTU" ]; then
+        ifconfig "$DEVICE" mtu "$ORIGINAL_RUNTIME_MTU" >/dev/null 2>&1
+    fi
+    rm -rf "$TMPDIR"
+    exit "$status"
+}
+trap cleanup EXIT HUP INT TERM
+
+INVALID_MAC=$(jq -nc '{interface:{spoofmac:"not-a-mac"}}')
+api_request POST "/api/interfaces/assignment/set_item/$IFACE" "$INVALID_MAC" \
+    > "$TMPDIR/invalid-mac.json"
+assert_json "$TMPDIR/invalid-mac.json" \
+    '.result == "failed" and (.validations | length > 0)'
+echo "Invalid MAC validation: PASS"
+
+INVALID_MTU=$(jq -nc '{interface:{mtu:"65536"}}')
+api_request POST "/api/interfaces/assignment/set_item/$IFACE" "$INVALID_MTU" \
+    > "$TMPDIR/invalid-mtu.json"
+assert_json "$TMPDIR/invalid-mtu.json" \
+    '.result == "failed" and (.validations | length > 0)'
+echo "Invalid MTU validation: PASS"
+
+ORIGINAL_BLOCK=$(jq -r '.interface.blockbogons' "$ORIGINAL")
+[ "$ORIGINAL_BLOCK" = 1 ] && TEST_BLOCK=0 || TEST_BLOCK=1
+ORIGINAL_MSS=$(jq -r '.interface.mss' "$ORIGINAL")
+[ "$ORIGINAL_MSS" = 1300 ] && TEST_MSS=1400 || TEST_MSS=1300
+FILTER_PAYLOAD=$(jq -nc --arg block "$TEST_BLOCK" --arg mss "$TEST_MSS" \
+    '{interface:{blockbogons:$block,mss:$mss}}')
+api_request POST "/api/interfaces/assignment/set_item/$IFACE" "$FILTER_PAYLOAD" \
+    > "$TMPDIR/filter-set.json"
+assert_json "$TMPDIR/filter-set.json" '.result == "saved"'
+jq -e --arg iface "$IFACE" '.[$iface].pending_action == "filter"' \
+    /tmp/.interfaces.todo >/dev/null
+echo "Filter-only scheduling: PASS"
+
+api_request POST '/api/interfaces/assignment/reconfigure' '{}' \
+    > "$TMPDIR/filter-apply.json"
+assert_json "$TMPDIR/filter-apply.json" '.status == "ok"'
+[ ! -e /tmp/.interfaces.todo ]
+echo "Filter-only apply: PASS"
+
+MTU_PAYLOAD=$(jq -nc --arg mtu "$TEST_MTU" '{interface:{mtu:$mtu}}')
+api_request POST "/api/interfaces/assignment/set_item/$IFACE" "$MTU_PAYLOAD" \
+    > "$TMPDIR/mtu-set.json"
+assert_json "$TMPDIR/mtu-set.json" '.result == "saved"'
+jq -e --arg iface "$IFACE" '.[$iface].pending_action == "reconfigure"' \
+    /tmp/.interfaces.todo >/dev/null
+
+api_request POST '/api/interfaces/assignment/reconfigure' '{}' \
+    > "$TMPDIR/mtu-apply.json"
+assert_json "$TMPDIR/mtu-apply.json" '.status == "ok"'
+sleep 2
+ifconfig "$DEVICE" | grep -E "(^|[[:space:]])mtu $TEST_MTU([[:space:]]|$)" >/dev/null
+echo "Runtime MTU apply: PASS"
+api_request GET "/api/interfaces/assignment/get_item/$IFACE" \
+    > "$TMPDIR/read-back.json"
+assert_json "$TMPDIR/read-back.json" \
+    ".interface.mtu == \"$TEST_MTU\" and .interface.mss == \"$TEST_MSS\""
+
+config_value() {
+    php -r '$xml=simplexml_load_file("/conf/config.xml"); echo (string)$xml->interfaces->{$argv[1]}->{$argv[2]};' \
+        "$IFACE" "$1"
+}
+[ "$(config_value mtu)" = "$TEST_MTU" ]
+[ "$(config_value mss)" = "$TEST_MSS" ]
+[ "$(config_value blockbogons)" = "$TEST_BLOCK" ]
+echo "API and config.xml read-back: PASS"
+echo "All interface basic-settings API tests passed"

--- a/src/opnsense/mvc/tests/app/models/OPNsense/Interfaces/NetworkInterfaceTest.php
+++ b/src/opnsense/mvc/tests/app/models/OPNsense/Interfaces/NetworkInterfaceTest.php
@@ -52,6 +52,104 @@ class NetworkInterfaceTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('WAN_GW', $data['wan']['gateway']);
     }
 
+    public function testBasicSettingsAreLoaded(): void
+    {
+        $data = $this->newModel()->interface->getNodeContent()['wan'];
+        $this->assertSame('1', $data['enable']);
+        $this->assertSame('1', $data['blockpriv']);
+        $this->assertSame('0', $data['blockbogons']);
+        $this->assertSame('1', $data['gateway_interface']);
+        $this->assertSame('1', $data['promisc']);
+        $this->assertSame('02:00:00:00:00:01', $data['spoofmac']);
+        $this->assertSame('9000', $data['mtu']);
+        $this->assertSame('1400', $data['mss']);
+    }
+
+    public function testFilterOnlySettingsScheduleFilterReload(): void
+    {
+        $model = $this->newModel();
+        $node = $model->getNodeByReference('interface.wan');
+        $node->blockbogons->setValue('1');
+        $node->mss->setValue('1300');
+        $this->assertTrue($model->serializeToConfig());
+
+        $config = Config::getInstance()->object()->interfaces->wan;
+        $this->assertSame('1', (string)$config->blockbogons);
+        $this->assertSame('1300', (string)$config->mss);
+        $this->assertSame('filter', $model->get_if_todo()['wan']['pending_action']);
+    }
+
+    public function testLinkSettingsScheduleReconfigure(): void
+    {
+        $model = $this->newModel();
+        $node = $model->getNodeByReference('interface.wan');
+        $node->mtu->setValue('1500');
+        $node->spoofmac->setValue('02:00:00:00:00:02');
+        $this->assertTrue($model->serializeToConfig());
+
+        $config = Config::getInstance()->object()->interfaces->wan;
+        $this->assertSame('1500', (string)$config->mtu);
+        $this->assertSame('02:00:00:00:00:02', (string)$config->spoofmac);
+        $this->assertSame('reconfigure', $model->get_if_todo()['wan']['pending_action']);
+    }
+
+    public function testReconfigureTakesPrecedenceOverFilterReload(): void
+    {
+        $model = $this->newModel();
+        $model->getNodeByReference('interface.wan')->mtu->setValue('1500');
+        $this->assertTrue($model->serializeToConfig());
+
+        $model = $this->newModel();
+        $model->getNodeByReference('interface.wan')->blockpriv->setValue('0');
+        $this->assertTrue($model->serializeToConfig());
+        $this->assertSame('reconfigure', $model->get_if_todo()['wan']['pending_action']);
+    }
+
+    public function testDisablingInterfaceRemovesEnableAndSchedulesReconfigure(): void
+    {
+        $model = $this->newModel();
+        $model->getNodeByReference('interface.wan')->enable->setValue('0');
+        $this->assertTrue($model->serializeToConfig());
+        $this->assertFalse(isset(Config::getInstance()->object()->interfaces->wan->enable));
+        $this->assertSame('reconfigure', $model->get_if_todo()['wan']['pending_action']);
+    }
+
+    public function testInvalidMacAddressIsRejected(): void
+    {
+        $model = $this->newModel();
+        $model->getNodeByReference('interface.wan')->spoofmac->setValue('not-a-mac');
+        $this->assertNotEmpty($model->performValidation()->getMessages());
+    }
+
+    public function testJumboMtuIsAcceptedAndOversizedMtuIsRejected(): void
+    {
+        $model = $this->newModel();
+        $model->getNodeByReference('interface.wan')->mtu->setValue('9000');
+        $this->assertEmpty($model->performValidation()->getMessages());
+
+        $model->getNodeByReference('interface.wan')->mtu->setValue('65536');
+        $this->assertNotEmpty($model->performValidation()->getMessages());
+    }
+
+    public function testNewInterfaceCopiesBasicSettingsAndSchedulesApply(): void
+    {
+        $model = $this->newModel();
+        $node = $model->interface->add();
+        $node->if->setValue('em1');
+        $node->descr->setValue('TEST');
+        $node->enable->setValue('1');
+        $node->mtu->setValue('9000');
+        $node->blockbogons->setValue('1');
+        $this->assertTrue($model->serializeToConfig());
+
+        $config = Config::getInstance()->object()->interfaces->opt1;
+        $this->assertSame('em1', (string)$config->if);
+        $this->assertSame('1', (string)$config->enable);
+        $this->assertSame('9000', (string)$config->mtu);
+        $this->assertSame('1', (string)$config->blockbogons);
+        $this->assertSame('reconfigure', $model->get_if_todo()['opt1']['pending_action']);
+    }
+
     public function testAddressRequiresPrefix(): void
     {
         $model = $this->newModel();

--- a/src/opnsense/mvc/tests/app/models/OPNsense/Interfaces/NetworkInterfaceTest/config.xml
+++ b/src/opnsense/mvc/tests/app/models/OPNsense/Interfaces/NetworkInterfaceTest/config.xml
@@ -4,6 +4,13 @@
     <wan>
       <if>em0</if>
       <descr>WAN</descr>
+      <enable>1</enable>
+      <blockpriv>1</blockpriv>
+      <gateway_interface>1</gateway_interface>
+      <promisc>1</promisc>
+      <spoofmac>02:00:00:00:00:01</spoofmac>
+      <mtu>9000</mtu>
+      <mss>1400</mss>
       <ipaddr>192.0.2.2</ipaddr>
       <subnet>24</subnet>
       <gateway>WAN_GW</gateway>

--- a/src/opnsense/scripts/interfaces/apply_pending_if_changes.php
+++ b/src/opnsense/scripts/interfaces/apply_pending_if_changes.php
@@ -52,10 +52,16 @@ if (is_array($config['interfaces'])) {
             $device = $family == 6 ? get_real_interface($id, 'inet6') : $ifcfg['if'];
             interfaces_addresses_flush($device, $family);
         }
-        if (in_array($pending_act, ['delete', 'relink'])) {
+        if (
+            in_array($pending_act, ['delete', 'relink']) ||
+            ($pending_act == 'reconfigure' && !isset($ifcfg['enable']))
+        ) {
             interface_reset($id);
         }
-        if (in_array($pending_act, ['relink', 'reconfigure'])) {
+        if (
+            in_array($pending_act, ['relink', 'reconfigure']) &&
+            isset($ifcfg['enable'])
+        ) {
             $to_configure[] = $id;
         }
     }


### PR DESCRIPTION
Adds basic interface settings to the modern assignment API: enable state, MTU, MSS, spoof MAC, promiscuous mode, private/bogon filtering, and gateway-interface mode. Includes action prioritization, disabled-interface reset handling, new-assignment apply scheduling, unit tests, and an HTTP API rollback test.