### PR TITLE
interfaces: add assignment address modes

### DIFF
--- a/src/opnsense/mvc/app/models/OPNsense/Interfaces/NetworkInterface.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Interfaces/NetworkInterface.php
@@ -40,6 +40,129 @@ class NetworkInterface extends BaseModel
     private const RECONFIGURE_FIELDS = ['enable', 'spoofmac', 'promisc', 'mtu'];
     private const FILTER_FIELDS = ['blockpriv', 'blockbogons', 'gateway_interface', 'mss'];
     private const BOOLEAN_FIELDS = ['enable', 'blockpriv', 'blockbogons', 'gateway_interface', 'promisc'];
+    private const DHCP4_FIELDS = ['dhcphostname', 'alias-address', 'alias-subnet', 'dhcprejectfrom'];
+    private const DHCP6_FIELDS = [
+        'dhcp6-ia-pd-len',
+        'dhcp6-ia-pd-send-hint',
+        'dhcp6prefixonly',
+        'dhcp6usev4iface',
+        'dhcp6vlanprio'
+    ];
+    private const TRACK6_FIELDS = ['track6-interface', 'track6-prefix-id', 'track6_assoc_pd'];
+    private const DYNAMIC_BOOLEAN_FIELDS = [
+        'dhcp6-ia-pd-send-hint',
+        'dhcp6prefixonly',
+        'dhcp6usev4iface'
+    ];
+    private const MANAGED_IPV4_MODES = ['none', 'static', 'dhcp'];
+    private const MANAGED_IPV6_MODES = ['none', 'static', 'linklocal', 'slaac', 'dhcp6', 'track6', 'idassoc6'];
+
+    private function address_mode($address, $family)
+    {
+        $flag = $family == 6 ? FILTER_FLAG_IPV6 : FILTER_FLAG_IPV4;
+        if ($address !== '' && filter_var($address, FILTER_VALIDATE_IP, $flag) !== false) {
+            return 'static';
+        }
+        return $address === '' ? 'none' : $address;
+    }
+
+    private function effective_mode($interface, $family)
+    {
+        $mode_field = $family == 6 ? 'type6' : 'type';
+        $address_field = $family == 6 ? 'ipaddrv6' : 'ipaddr';
+        $mode = $interface->$mode_field->getValue();
+        if (
+            !$interface->$mode_field->isFieldChanged() &&
+            $mode != 'static' &&
+            $interface->$address_field->isFieldChanged() &&
+            $interface->$address_field->getValue() !== ''
+        ) {
+            return 'static';
+        }
+        return $mode;
+    }
+
+    private function set_config_field($node, $field, $value)
+    {
+        $boolean_fields = array_merge(self::BOOLEAN_FIELDS, self::DYNAMIC_BOOLEAN_FIELDS);
+        if (in_array($field, $boolean_fields)) {
+            if ($value == '1') {
+                $node->$field = '1';
+            } else {
+                unset($node->$field);
+            }
+        } elseif ($value === '') {
+            unset($node->$field);
+        } else {
+            $node->$field = $value;
+        }
+    }
+
+    private function serialize_family($intf, $model, $data, $family)
+    {
+        if ($family == 6) {
+            $mode_field = 'type6';
+            $address_field = 'ipaddrv6';
+            $subnet_field = 'subnetv6';
+            $gateway_field = 'gatewayv6';
+            $all_dynamic = array_merge(self::DHCP6_FIELDS, self::TRACK6_FIELDS);
+        } else {
+            $mode_field = 'type';
+            $address_field = 'ipaddr';
+            $subnet_field = 'subnet';
+            $gateway_field = 'gateway';
+            $all_dynamic = self::DHCP4_FIELDS;
+        }
+
+        $mode = $data[$mode_field];
+        $mode_changed = $model->$mode_field->isFieldChanged();
+        if (
+            !$mode_changed &&
+            $mode != 'static' &&
+            $model->$address_field->isFieldChanged() &&
+            $data[$address_field] !== ''
+        ) {
+            /* Backwards compatibility for the static-address-only API payload. */
+            $mode = 'static';
+            $mode_changed = true;
+        }
+        $changed = $mode_changed;
+        if ($mode_changed) {
+            foreach (array_merge([$address_field, $subnet_field, $gateway_field], $all_dynamic) as $field) {
+                unset($intf->$field);
+            }
+            if ($mode == 'static') {
+                foreach ([$address_field, $subnet_field, $gateway_field] as $field) {
+                    $this->set_config_field($intf, $field, $data[$field]);
+                }
+            } elseif ($mode != 'none') {
+                $intf->$address_field = $mode;
+            }
+        } elseif ($mode == 'static') {
+            foreach ([$address_field, $subnet_field, $gateway_field] as $field) {
+                if ($model->$field->isFieldChanged()) {
+                    $this->set_config_field($intf, $field, $data[$field]);
+                    $changed = true;
+                }
+            }
+        }
+
+        $active_fields = [];
+        if ($family == 4 && $mode == 'dhcp') {
+            $active_fields = self::DHCP4_FIELDS;
+        } elseif ($family == 6 && $mode == 'dhcp6') {
+            $active_fields = self::DHCP6_FIELDS;
+        } elseif ($family == 6 && in_array($mode, ['track6', 'idassoc6'])) {
+            $active_fields = self::TRACK6_FIELDS;
+        }
+        foreach ($active_fields as $field) {
+            if ($mode_changed || $model->$field->isFieldChanged()) {
+                $this->set_config_field($intf, $field, $data[$field]);
+                $changed = true;
+            }
+        }
+        return $changed;
+    }
 
     /**
      * @param array $payload data to store
@@ -126,6 +249,18 @@ class NetworkInterface extends BaseModel
                 }
                 $node->$field->markUnchanged();
             }
+            $node->type = $this->address_mode((string)$intf->ipaddr, 4);
+            $node->type6 = $this->address_mode((string)$intf->ipaddrv6, 6);
+            $node->type->markUnchanged();
+            $node->type6->markUnchanged();
+            foreach (array_merge(self::DHCP4_FIELDS, self::DHCP6_FIELDS, self::TRACK6_FIELDS) as $field) {
+                if (in_array($field, self::DYNAMIC_BOOLEAN_FIELDS)) {
+                    $node->$field = empty((string)$intf->$field) ? '0' : '1';
+                } else {
+                    $node->$field = (string)$intf->$field;
+                }
+                $node->$field->markUnchanged();
+            }
             foreach (['' => FILTER_FLAG_IPV4, 'v6' => FILTER_FLAG_IPV6] as $suffix => $filter_flag) {
                 $addr_field = 'ipaddr' . $suffix;
                 $subnet_field = 'subnet' . $suffix;
@@ -192,28 +327,15 @@ class NetworkInterface extends BaseModel
                     $this->store_if_todo($key, ['pending_action' => $pending_action]);
                 }
                 $changed_families = [];
-                foreach (['ipaddr', 'subnet', 'gateway', 'ipaddrv6', 'subnetv6', 'gatewayv6'] as $field) {
-                    if ($model_interfaces[$key]->$field->isFieldChanged()) {
-                        $changed_families[] = substr($field, -2) == 'v6' ? 6 : 4;
-                        $value = $interfaces[$key][$field];
-                        if ($value === '') {
-                            if (
-                                in_array($field, ['ipaddr', 'ipaddrv6']) &&
-                                (string)$intf->$field !== '' &&
-                                filter_var((string)$intf->$field, FILTER_VALIDATE_IP) === false
-                            ) {
-                                continue;
-                            }
-                            unset($intf->$field);
-                        } else {
-                            $intf->$field = $value;
-                        }
+                foreach ([4, 6] as $family) {
+                    if ($this->serialize_family($intf, $model_interfaces[$key], $interfaces[$key], $family)) {
+                        $changed_families[] = $family;
                     }
                 }
                 if (!empty($changed_families)) {
                     $this->store_if_todo($key, [
                         'pending_action' => 'reconfigure',
-                        'pending_families' => array_values(array_unique($changed_families))
+                        'pending_families' => $changed_families
                     ]);
                 }
                 /* flush actions that need to be applied, for which we need history */
@@ -242,11 +364,8 @@ class NetworkInterface extends BaseModel
                         $newif->$field = $value;
                     }
                 }
-                foreach (['ipaddr', 'subnet', 'gateway', 'ipaddrv6', 'subnetv6', 'gatewayv6'] as $field) {
-                    if ($intf[$field] !== '') {
-                        $newif->$field = $intf[$field];
-                    }
-                }
+                $this->serialize_family($newif, $model_interfaces[$key], $intf, 4);
+                $this->serialize_family($newif, $model_interfaces[$key], $intf, 6);
                 $this->store_if_todo($new_key, ['pending_action' => 'reconfigure']);
                 $next_if++;
             }
@@ -262,27 +381,47 @@ class NetworkInterface extends BaseModel
                 continue;
             }
             $key = $if->__reference;
-            foreach ([['ipaddr', 'subnet'], ['ipaddrv6', 'subnetv6']] as $fields) {
-                $has_address = $if->{$fields[0]}->getValue() !== '';
-                $has_prefix = $if->{$fields[1]}->getValue() !== '';
-                if ($has_address !== $has_prefix) {
-                    $msg = gettext('A static IP address and its prefix length must be configured together.');
-                    $messages->appendMessage(new Message($msg, $key . '.' . $fields[0]));
-                    $messages->appendMessage(new Message($msg, $key . '.' . $fields[1]));
+            foreach ([
+                4 => ['type', 'ipaddr', 'subnet', 'gateway', 'inet', self::MANAGED_IPV4_MODES],
+                6 => ['type6', 'ipaddrv6', 'subnetv6', 'gatewayv6', 'inet6', self::MANAGED_IPV6_MODES]
+            ] as $family => $fields) {
+                [$mode_field, $address_field, $subnet_field, $gateway_field, $protocol, $managed_modes] = $fields;
+                $mode = $this->effective_mode($if, $family);
+                $mode_changed = $if->$mode_field->isFieldChanged();
+                $config_address = isset(Config::getInstance()->object()->interfaces->$ifname) ?
+                    (string)Config::getInstance()->object()->interfaces->$ifname->$address_field : '';
+                $current_mode = $this->address_mode($config_address, $family);
+                if ($mode_changed && !in_array($mode, $managed_modes) && $mode != $current_mode) {
+                    $msg = gettext('This address mode is managed by another interface subsystem.');
+                    $messages->appendMessage(new Message($msg, $key . '.' . $mode_field));
                 }
-            }
-            foreach ([['gateway', 'ipaddr', 'inet'], ['gatewayv6', 'ipaddrv6', 'inet6']] as $fields) {
-                $gateway = $if->{$fields[0]}->getValue();
-                if ($gateway !== '' && $if->{$fields[1]}->getValue() === '') {
+
+                $has_address = $if->$address_field->getValue() !== '';
+                $has_prefix = $if->$subnet_field->getValue() !== '';
+                if ($mode == 'static' && (!$has_address || !$has_prefix)) {
+                    $msg = gettext('A static IP address and its prefix length must be configured together.');
+                    $messages->appendMessage(new Message($msg, $key . '.' . $address_field));
+                    $messages->appendMessage(new Message($msg, $key . '.' . $subnet_field));
+                } elseif ($mode != 'static' && !$mode_changed) {
+                    foreach ([$address_field, $subnet_field, $gateway_field] as $field) {
+                        if ($if->$field->isFieldChanged() && $if->$field->getValue() !== '') {
+                            $msg = gettext('Static addressing fields require static address mode.');
+                            $messages->appendMessage(new Message($msg, $key . '.' . $field));
+                        }
+                    }
+                }
+
+                $gateway = $if->$gateway_field->getValue();
+                if ($mode == 'static' && $gateway !== '' && !$has_address) {
                     $msg = gettext('A gateway requires a static IP address of the same address family.');
-                    $messages->appendMessage(new Message($msg, $key . '.' . $fields[0]));
-                } elseif ($gateway !== '') {
+                    $messages->appendMessage(new Message($msg, $key . '.' . $gateway_field));
+                } elseif ($mode == 'static' && $gateway !== '') {
                     $gateway_found = false;
                     foreach (Config::getInstance()->object()->xpath('//OPNsense/Gateways/gateway_item') as $gateway_node) {
                         if (
                             (string)$gateway_node->name === $gateway &&
                             (string)$gateway_node->interface === $ifname &&
-                            (string)$gateway_node->ipprotocol === $fields[2]
+                            (string)$gateway_node->ipprotocol === $protocol
                         ) {
                             $gateway_found = true;
                             break;
@@ -290,7 +429,84 @@ class NetworkInterface extends BaseModel
                     }
                     if (!$gateway_found) {
                         $msg = gettext('The selected gateway does not exist for this interface and address family.');
-                        $messages->appendMessage(new Message($msg, $key . '.' . $fields[0]));
+                        $messages->appendMessage(new Message($msg, $key . '.' . $gateway_field));
+                    }
+                }
+            }
+
+            $mode_requirements = [
+                'dhcp' => self::DHCP4_FIELDS,
+                'dhcp6' => self::DHCP6_FIELDS,
+                'track6' => self::TRACK6_FIELDS,
+                'idassoc6' => self::TRACK6_FIELDS
+            ];
+            foreach ($mode_requirements as $required_mode => $fields) {
+                $actual_mode = $required_mode == 'dhcp' ? $this->effective_mode($if, 4) : $this->effective_mode($if, 6);
+                foreach ($fields as $field) {
+                    $value = $if->$field->getValue();
+                    if ($if->$field->isFieldChanged() && $value !== '' && $value != '0' && $actual_mode != $required_mode) {
+                        if (!in_array($actual_mode, ['track6', 'idassoc6']) || !in_array($required_mode, ['track6', 'idassoc6'])) {
+                            $msg = sprintf(gettext('Field %s is not valid for the selected address mode.'), $field);
+                            $messages->appendMessage(new Message($msg, $key . '.' . $field));
+                        }
+                    }
+                }
+            }
+
+            if ($this->effective_mode($if, 4) == 'dhcp') {
+                $has_alias = $if->{'alias-address'}->getValue() !== '';
+                $has_alias_subnet = $if->{'alias-subnet'}->getValue() !== '';
+                if ($has_alias !== $has_alias_subnet) {
+                    $msg = gettext('A DHCP alias address and its prefix length must be configured together.');
+                    $messages->appendMessage(new Message($msg, $key . '.alias-address'));
+                    $messages->appendMessage(new Message($msg, $key . '.alias-subnet'));
+                }
+                foreach (array_filter(array_map('trim', explode(',', $if->dhcprejectfrom->getValue()))) as $address) {
+                    if (filter_var($address, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) === false) {
+                        $msg = gettext('A valid IPv4 address list must be specified for rejected DHCP servers.');
+                        $messages->appendMessage(new Message($msg, $key . '.dhcprejectfrom'));
+                        break;
+                    }
+                }
+            }
+
+            $ipv6_mode = $this->effective_mode($if, 6);
+            if (in_array($ipv6_mode, ['track6', 'idassoc6'])) {
+                $track_interface = $if->{'track6-interface'}->getValue();
+                if ($track_interface === '') {
+                    $messages->appendMessage(new Message(
+                        gettext('A tracked interface is required.'),
+                        $key . '.track6-interface'
+                    ));
+                } elseif ($track_interface == $ifname) {
+                    $messages->appendMessage(new Message(
+                        gettext('An interface cannot track itself.'),
+                        $key . '.track6-interface'
+                    ));
+                } elseif (!isset(Config::getInstance()->object()->interfaces->$track_interface)) {
+                    $messages->appendMessage(new Message(
+                        gettext('The tracked interface does not exist.'),
+                        $key . '.track6-interface'
+                    ));
+                } else {
+                    $tracked = Config::getInstance()->object()->interfaces->$track_interface;
+                    $tracked_mode = $this->address_mode((string)$tracked->ipaddrv6, 6);
+                    if (!in_array($tracked_mode, ['dhcp6', 'slaac'])) {
+                        $messages->appendMessage(new Message(
+                            gettext('The tracked interface must use DHCPv6 or SLAAC.'),
+                            $key . '.track6-interface'
+                        ));
+                    }
+                    $prefix_id = $if->{'track6-prefix-id'}->getValue();
+                    $delegation = (string)$tracked->{'dhcp6-ia-pd-len'};
+                    if ($prefix_id !== '' && ctype_digit($delegation) && $delegation >= 48 && $delegation <= 64) {
+                        $maximum = (2 ** (64 - (int)$delegation)) - 1;
+                        if ((int)$prefix_id > $maximum) {
+                            $messages->appendMessage(new Message(
+                                gettext('The tracked prefix ID is outside the delegated prefix range.'),
+                                $key . '.track6-prefix-id'
+                            ));
+                        }
                     }
                 }
             }

--- a/src/opnsense/mvc/app/models/OPNsense/Interfaces/NetworkInterface.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Interfaces/NetworkInterface.xml
@@ -1,6 +1,6 @@
 <model>
     <mount>:memory:</mount>
-    <version>0.0.3</version>
+    <version>0.0.4</version>
     <description>Interface assignments</description>
     <items>
         <interface type="ArrayField">
@@ -51,6 +51,76 @@
                 <MinimumValue>576</MinimumValue>
                 <MaximumValue>65535</MaximumValue>
             </mss>
+            <type type="OptionField">
+                <Default>none</Default>
+                <Required>Y</Required>
+                <OptionValues>
+                    <none value="none">None</none>
+                    <static value="static">Static IPv4</static>
+                    <dhcp value="dhcp">DHCP</dhcp>
+                    <ppp value="ppp">PPP</ppp>
+                    <pppoe value="pppoe">PPPoE</pppoe>
+                    <pptp value="pptp">PPTP</pptp>
+                    <l2tp value="l2tp">L2TP</l2tp>
+                </OptionValues>
+            </type>
+            <dhcphostname type="HostnameField">
+                <IpAllowed>N</IpAllowed>
+            </dhcphostname>
+            <alias-address type="NetworkField">
+                <AddressFamily>ipv4</AddressFamily>
+                <NetMaskAllowed>N</NetMaskAllowed>
+                <WildcardEnabled>N</WildcardEnabled>
+            </alias-address>
+            <alias-subnet type="IntegerField">
+                <MinimumValue>1</MinimumValue>
+                <MaximumValue>32</MaximumValue>
+            </alias-subnet>
+            <dhcprejectfrom type="TextField"/>
+            <type6 type="OptionField">
+                <Default>none</Default>
+                <Required>Y</Required>
+                <OptionValues>
+                    <none value="none">None</none>
+                    <static value="static">Static IPv6</static>
+                    <linklocal value="linklocal">Link-local</linklocal>
+                    <slaac value="slaac">SLAAC</slaac>
+                    <dhcp6 value="dhcp6">DHCPv6</dhcp6>
+                    <track6 value="track6">Track interface</track6>
+                    <idassoc6 value="idassoc6">Track interface (legacy)</idassoc6>
+                    <_6rd value="6rd">6rd</_6rd>
+                    <_6to4 value="6to4">6to4</_6to4>
+                    <pppoev6 value="pppoev6">PPPoE IPv6</pppoev6>
+                </OptionValues>
+            </type6>
+            <dhcp6-ia-pd-len type="IntegerField">
+                <MinimumValue>48</MinimumValue>
+                <MaximumValue>64</MaximumValue>
+            </dhcp6-ia-pd-len>
+            <dhcp6-ia-pd-send-hint type="BooleanField">
+                <Default>0</Default>
+                <Required>Y</Required>
+            </dhcp6-ia-pd-send-hint>
+            <dhcp6prefixonly type="BooleanField">
+                <Default>0</Default>
+                <Required>Y</Required>
+            </dhcp6prefixonly>
+            <dhcp6usev4iface type="BooleanField">
+                <Default>0</Default>
+                <Required>Y</Required>
+            </dhcp6usev4iface>
+            <dhcp6vlanprio type="IntegerField">
+                <MinimumValue>0</MinimumValue>
+                <MaximumValue>7</MaximumValue>
+            </dhcp6vlanprio>
+            <track6-interface type="TextField"/>
+            <track6-prefix-id type="IntegerField">
+                <MinimumValue>0</MinimumValue>
+                <MaximumValue>65535</MaximumValue>
+            </track6-prefix-id>
+            <track6_assoc_pd type="IntegerField">
+                <MinimumValue>0</MinimumValue>
+            </track6_assoc_pd>
             <ipaddr type="NetworkField">
                 <AddressFamily>ipv4</AddressFamily>
                 <NetMaskAllowed>N</NetMaskAllowed>

--- a/src/opnsense/mvc/tests/api/interfaces_assignment_address_modes.sh
+++ b/src/opnsense/mvc/tests/api/interfaces_assignment_address_modes.sh
@@ -1,0 +1,131 @@
+#!/bin/sh
+set -eu
+
+: "${OPNSENSE_API_KEY:?Set OPNSENSE_API_KEY}"
+: "${OPNSENSE_API_SECRET:?Set OPNSENSE_API_SECRET}"
+
+BASE_URL=${OPNSENSE_URL:-http://127.0.0.1}
+IFACE=${OPNSENSE_TEST_INTERFACE:-lan}
+TMPDIR=$(mktemp -d /tmp/interfaces-mode-api-test.XXXXXX)
+ORIGINAL="$TMPDIR/original.json"
+
+api_request() {
+    method=$1
+    path=$2
+    data=${3-}
+    if [ "$method" = GET ]; then
+        curl -fsS -u "$OPNSENSE_API_KEY:$OPNSENSE_API_SECRET" "$BASE_URL$path"
+    else
+        curl -fsS -u "$OPNSENSE_API_KEY:$OPNSENSE_API_SECRET" \
+            -H 'Content-Type: application/json' -X "$method" \
+            -d "$data" "$BASE_URL$path"
+    fi
+}
+
+assert_json() {
+    file=$1
+    expression=$2
+    jq -e "$expression" "$file" >/dev/null || {
+        echo "Assertion failed: $expression" >&2
+        cat "$file" >&2
+        exit 1
+    }
+}
+api_request GET "/api/interfaces/assignment/get_item/$IFACE" > "$ORIGINAL"
+DEVICE=$(jq -r '.interface.if | to_entries[] | select(.value.selected == 1) | .key' "$ORIGINAL")
+TYPE=$(jq -r '.interface.type | to_entries[] | select(.value.selected == 1) | .key' "$ORIGINAL")
+TYPE6=$(jq -r '.interface.type6 | to_entries[] | select(.value.selected == 1) | .key' "$ORIGINAL")
+ORIGINAL_IPV4=$(jq -r '.interface.ipaddr' "$ORIGINAL")
+ORIGINAL_PREFIX4=$(jq -r '.interface.subnet' "$ORIGINAL")
+[ -n "$DEVICE" ] || { echo "Assigned device not found" >&2; exit 1; }
+
+RESTORE_PAYLOAD=$(jq -c --arg type "$TYPE" --arg type6 "$TYPE6" '{
+    interface: {
+        type: $type,
+        type6: $type6,
+        ipaddr: .interface.ipaddr,
+        subnet: .interface.subnet,
+        gateway: .interface.gateway,
+        ipaddrv6: .interface.ipaddrv6,
+        subnetv6: .interface.subnetv6,
+        gatewayv6: .interface.gatewayv6,
+        dhcphostname: .interface.dhcphostname,
+        "alias-address": .interface["alias-address"],
+        "alias-subnet": .interface["alias-subnet"],
+        dhcprejectfrom: .interface.dhcprejectfrom,
+        "dhcp6-ia-pd-len": .interface["dhcp6-ia-pd-len"],
+        "dhcp6-ia-pd-send-hint": .interface["dhcp6-ia-pd-send-hint"],
+        dhcp6prefixonly: .interface.dhcp6prefixonly,
+        dhcp6usev4iface: .interface.dhcp6usev4iface,
+        dhcp6vlanprio: .interface.dhcp6vlanprio,
+        "track6-interface": .interface["track6-interface"],
+        "track6-prefix-id": .interface["track6-prefix-id"],
+        track6_assoc_pd: .interface.track6_assoc_pd
+    }
+}' "$ORIGINAL")
+
+cleanup() {
+    status=$?
+    trap - EXIT HUP INT TERM
+    set +e
+    api_request POST "/api/interfaces/assignment/set_item/$IFACE" \
+        "$RESTORE_PAYLOAD" > "$TMPDIR/restore-set.json"
+    api_request POST '/api/interfaces/assignment/reconfigure' '{}' \
+        > "$TMPDIR/restore-apply.json"
+    rm -rf "$TMPDIR"
+    exit "$status"
+}
+trap cleanup EXIT HUP INT TERM
+
+UNSUPPORTED=$(jq -nc '{interface:{type:"pppoe"}}')
+api_request POST "/api/interfaces/assignment/set_item/$IFACE" "$UNSUPPORTED" \
+    > "$TMPDIR/unsupported.json"
+assert_json "$TMPDIR/unsupported.json" \
+    '.result == "failed" and (.validations | length > 0)'
+echo "Unsupported mode validation: PASS"
+
+INVALID_HOST=$(jq -nc '{interface:{type:"dhcp",dhcphostname:"bad host"}}')
+api_request POST "/api/interfaces/assignment/set_item/$IFACE" "$INVALID_HOST" \
+    > "$TMPDIR/invalid-host.json"
+assert_json "$TMPDIR/invalid-host.json" \
+    '.result == "failed" and (.validations | length > 0)'
+echo "DHCP hostname validation: PASS"
+DHCP_PAYLOAD=$(jq -nc '{interface:{type:"dhcp",dhcphostname:"biptec-api-test"}}')
+api_request POST "/api/interfaces/assignment/set_item/$IFACE" "$DHCP_PAYLOAD" \
+    > "$TMPDIR/dhcp-set.json"
+assert_json "$TMPDIR/dhcp-set.json" '.result == "saved"'
+jq -e --arg iface "$IFACE" \
+    '.[$iface].pending_action == "reconfigure" and (.[$iface].pending_families | index(4) != null)' \
+    /tmp/.interfaces.todo >/dev/null
+
+echo "DHCP mode scheduling: PASS"
+api_request POST '/api/interfaces/assignment/reconfigure' '{}' \
+    > "$TMPDIR/dhcp-apply.json"
+assert_json "$TMPDIR/dhcp-apply.json" '.status == "ok"'
+sleep 2
+CONFIG_MODE=$(php -r '$x=simplexml_load_file("/conf/config.xml"); echo (string)$x->interfaces->{$argv[1]}->ipaddr;' "$IFACE")
+[ "$CONFIG_MODE" = dhcp ]
+! ifconfig "$DEVICE" | grep -F "inet $ORIGINAL_IPV4 " >/dev/null
+echo "Static to DHCP runtime transition: PASS"
+
+api_request GET "/api/interfaces/assignment/get_item/$IFACE" \
+    > "$TMPDIR/dhcp-get.json"
+assert_json "$TMPDIR/dhcp-get.json" \
+    '.interface.type | to_entries | any(.key == "dhcp" and .value.selected == 1)'
+assert_json "$TMPDIR/dhcp-get.json" '.interface.dhcphostname == "biptec-api-test"'
+echo "DHCP API read-back: PASS"
+
+api_request POST "/api/interfaces/assignment/set_item/$IFACE" "$RESTORE_PAYLOAD" \
+    > "$TMPDIR/static-set.json"
+assert_json "$TMPDIR/static-set.json" '.result == "saved"'
+api_request POST '/api/interfaces/assignment/reconfigure' '{}' \
+    > "$TMPDIR/static-apply.json"
+assert_json "$TMPDIR/static-apply.json" '.status == "ok"'
+sleep 2
+if [ "$TYPE" = static ]; then
+    ifconfig "$DEVICE" | grep -F "inet $ORIGINAL_IPV4 " >/dev/null
+    RESTORED_PREFIX=$(php -r '$x=simplexml_load_file("/conf/config.xml"); echo (string)$x->interfaces->{$argv[1]}->subnet;' "$IFACE")
+    [ "$RESTORED_PREFIX" = "$ORIGINAL_PREFIX4" ]
+fi
+echo "Address mode rollback: PASS"
+echo "All interface address-mode API tests passed"

--- a/src/opnsense/mvc/tests/app/models/OPNsense/Interfaces/NetworkInterfaceTest.php
+++ b/src/opnsense/mvc/tests/app/models/OPNsense/Interfaces/NetworkInterfaceTest.php
@@ -150,6 +150,160 @@ class NetworkInterfaceTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('reconfigure', $model->get_if_todo()['opt1']['pending_action']);
     }
 
+    public function testAddressModesAreLoaded(): void
+    {
+        $node = $this->newModel()->getNodeByReference('interface.wan');
+        $this->assertSame('static', $node->type->getValue());
+        $this->assertSame('none', $node->type6->getValue());
+    }
+
+    public function testDhcpModesAndOptionsAreLoaded(): void
+    {
+        $config = Config::getInstance()->object()->interfaces->wan;
+        $config->ipaddr = 'dhcp';
+        $config->dhcphostname = 'edge-router';
+        $config->{'alias-address'} = '192.0.2.10';
+        $config->{'alias-subnet'} = '24';
+        $config->ipaddrv6 = 'dhcp6';
+        $config->{'dhcp6-ia-pd-len'} = '56';
+        $config->{'dhcp6-ia-pd-send-hint'} = '1';
+
+        $node = $this->newModel()->getNodeByReference('interface.wan');
+        $this->assertSame('dhcp', $node->type->getValue());
+        $this->assertSame('edge-router', $node->dhcphostname->getValue());
+        $this->assertSame('192.0.2.10', $node->{'alias-address'}->getValue());
+        $this->assertSame('dhcp6', $node->type6->getValue());
+        $this->assertSame('56', $node->{'dhcp6-ia-pd-len'}->getValue());
+        $this->assertSame('1', $node->{'dhcp6-ia-pd-send-hint'}->getValue());
+    }
+
+    public function testSwitchToDhcpClearsStaticConfiguration(): void
+    {
+        $model = $this->newModel();
+        $node = $model->getNodeByReference('interface.wan');
+        $node->type->setValue('dhcp');
+        $node->dhcphostname->setValue('edge-router');
+        $node->{'alias-address'}->setValue('192.0.2.10');
+        $node->{'alias-subnet'}->setValue('24');
+        $node->dhcprejectfrom->setValue('192.0.2.20,192.0.2.21');
+        $this->assertEmpty($model->performValidation()->getMessages());
+        $this->assertTrue($model->serializeToConfig());
+
+        $config = Config::getInstance()->object()->interfaces->wan;
+        $this->assertSame('dhcp', (string)$config->ipaddr);
+        $this->assertFalse(isset($config->subnet));
+        $this->assertFalse(isset($config->gateway));
+        $this->assertSame('edge-router', (string)$config->dhcphostname);
+        $this->assertSame('192.0.2.10', (string)$config->{'alias-address'});
+        $this->assertSame([4], $model->get_if_todo()['wan']['pending_families']);
+    }
+
+    public function testSwitchToNoneClearsAddressFamily(): void
+    {
+        $model = $this->newModel();
+        $model->getNodeByReference('interface.wan')->type->setValue('none');
+        $this->assertEmpty($model->performValidation()->getMessages());
+        $this->assertTrue($model->serializeToConfig());
+        $config = Config::getInstance()->object()->interfaces->wan;
+        $this->assertFalse(isset($config->ipaddr));
+        $this->assertFalse(isset($config->subnet));
+        $this->assertFalse(isset($config->gateway));
+    }
+
+    public function testDhcpOptionsRequireDhcpMode(): void
+    {
+        $model = $this->newModel();
+        $model->getNodeByReference('interface.wan')->dhcphostname->setValue('edge-router');
+        $this->assertNotEmpty($model->performValidation()->getMessages());
+    }
+
+    public function testDhcpRejectListIsValidated(): void
+    {
+        $model = $this->newModel();
+        $node = $model->getNodeByReference('interface.wan');
+        $node->type->setValue('dhcp');
+        $node->dhcprejectfrom->setValue('192.0.2.20,invalid');
+        $this->assertNotEmpty($model->performValidation()->getMessages());
+    }
+
+    public function testSwitchToDhcpv6SerializesPrefixDelegation(): void
+    {
+        $model = $this->newModel();
+        $node = $model->getNodeByReference('interface.wan');
+        $node->type6->setValue('dhcp6');
+        $node->{'dhcp6-ia-pd-len'}->setValue('56');
+        $node->{'dhcp6-ia-pd-send-hint'}->setValue('1');
+        $node->dhcp6prefixonly->setValue('1');
+        $this->assertEmpty($model->performValidation()->getMessages());
+        $this->assertTrue($model->serializeToConfig());
+
+        $config = Config::getInstance()->object()->interfaces->wan;
+        $this->assertSame('dhcp6', (string)$config->ipaddrv6);
+        $this->assertSame('56', (string)$config->{'dhcp6-ia-pd-len'});
+        $this->assertSame('1', (string)$config->{'dhcp6-ia-pd-send-hint'});
+        $this->assertSame('1', (string)$config->dhcp6prefixonly);
+        $this->assertSame([6], $model->get_if_todo()['wan']['pending_families']);
+    }
+
+    public function testTrack6RequiresValidDelegatingInterface(): void
+    {
+        $config = Config::getInstance()->object();
+        $config->interfaces->wan->ipaddrv6 = 'dhcp6';
+        $config->interfaces->wan->{'dhcp6-ia-pd-len'} = '56';
+        $opt = $config->interfaces->addChild('opt1');
+        $opt->if = 'em1';
+        $opt->descr = 'LAN2';
+        $opt->enable = '1';
+
+        $model = $this->newModel();
+        $node = $model->getNodeByReference('interface.opt1');
+        $node->type6->setValue('track6');
+        $node->{'track6-interface'}->setValue('wan');
+        $node->{'track6-prefix-id'}->setValue('10');
+        $node->track6_assoc_pd->setValue('1');
+        $this->assertEmpty($model->performValidation()->getMessages());
+        $this->assertTrue($model->serializeToConfig());
+        $this->assertSame('track6', (string)$config->interfaces->opt1->ipaddrv6);
+        $this->assertSame('wan', (string)$config->interfaces->opt1->{'track6-interface'});
+        $this->assertSame('10', (string)$config->interfaces->opt1->{'track6-prefix-id'});
+    }
+
+    public function testTrack6PrefixMustFitDelegation(): void
+    {
+        $config = Config::getInstance()->object();
+        $config->interfaces->wan->ipaddrv6 = 'dhcp6';
+        $config->interfaces->wan->{'dhcp6-ia-pd-len'} = '56';
+        $opt = $config->interfaces->addChild('opt1');
+        $opt->if = 'em1';
+        $opt->descr = 'LAN2';
+        $opt->enable = '1';
+
+        $model = $this->newModel();
+        $node = $model->getNodeByReference('interface.opt1');
+        $node->type6->setValue('track6');
+        $node->{'track6-interface'}->setValue('wan');
+        $node->{'track6-prefix-id'}->setValue('256');
+        $this->assertNotEmpty($model->performValidation()->getMessages());
+    }
+
+    public function testUnsupportedModeCannotBeSelected(): void
+    {
+        $model = $this->newModel();
+        $model->getNodeByReference('interface.wan')->type->setValue('pppoe');
+        $this->assertNotEmpty($model->performValidation()->getMessages());
+    }
+
+    public function testExistingUnsupportedModeIsPreserved(): void
+    {
+        Config::getInstance()->object()->interfaces->wan->ipaddr = 'pppoe';
+        $model = $this->newModel();
+        $node = $model->getNodeByReference('interface.wan');
+        $this->assertSame('pppoe', $node->type->getValue());
+        $node->descr->setValue('Updated WAN');
+        $this->assertTrue($model->serializeToConfig());
+        $this->assertSame('pppoe', (string)Config::getInstance()->object()->interfaces->wan->ipaddr);
+    }
+
     public function testAddressRequiresPrefix(): void
     {
         $model = $this->newModel();


### PR DESCRIPTION
Stacked on #6. Adds safe IPv4 and IPv6 address modes to the modern assignment API: none/static/DHCP for IPv4 and none/static/link-local/SLAAC/DHCPv6/track6 for IPv6. Existing PPP and tunnel modes remain visible and are preserved but cannot be newly selected through this API. Includes DHCP/PD/track6 validation, backward compatibility for static-only payloads, unit tests, and a real HTTP static-to-DHCP rollback test.