### PR TITLE
auth: fix automated user creation metadata

### DIFF
--- a/plist
+++ b/plist
@@ -1078,7 +1078,12 @@
 /usr/local/opnsense/mvc/script/load_phalcon.php
 /usr/local/opnsense/mvc/script/run_migrations.php
 /usr/local/opnsense/mvc/script/run_validations.php
+/usr/local/opnsense/mvc/tests/api/auth_add_user.sh
+/usr/local/opnsense/mvc/tests/api/interfaces_assignment_address_modes.sh
+/usr/local/opnsense/mvc/tests/api/interfaces_assignment_basic_settings.sh
+/usr/local/opnsense/mvc/tests/api/interfaces_assignment_static_addressing.sh
 /usr/local/opnsense/mvc/tests/app/config/config.php
+/usr/local/opnsense/mvc/tests/app/library/OPNsense/Auth/ApiKeyCommandTest.php
 /usr/local/opnsense/mvc/tests/app/library/OPNsense/Core/ConfigConfig/backup/array.xml
 /usr/local/opnsense/mvc/tests/app/library/OPNsense/Core/ConfigConfig/backup/object.xml
 /usr/local/opnsense/mvc/tests/app/library/OPNsense/Core/ConfigTest.php
@@ -1131,6 +1136,10 @@
 /usr/local/opnsense/mvc/tests/app/models/OPNsense/Base/FieldTypes/VirtualIPFieldTest.php
 /usr/local/opnsense/mvc/tests/app/models/OPNsense/Base/FieldTypes/VirtualIPFieldTest/config.xml
 /usr/local/opnsense/mvc/tests/app/models/OPNsense/Dnsmasq/FieldTypes/HostnameFieldTest.php
+/usr/local/opnsense/mvc/tests/app/models/OPNsense/Interfaces/NetworkInterfaceTest.php
+/usr/local/opnsense/mvc/tests/app/models/OPNsense/Interfaces/NetworkInterfaceTest/config.xml
+/usr/local/opnsense/mvc/tests/app/models/OPNsense/Interfaces/VlanTest.php
+/usr/local/opnsense/mvc/tests/app/models/OPNsense/Interfaces/VlanTest/config.xml
 /usr/local/opnsense/mvc/tests/app/models/OPNsense/Kea/FieldTypes/KeaOptionDataFieldTest.php
 /usr/local/opnsense/mvc/tests/phpunit.xml
 /usr/local/opnsense/mvc/tests/setup.php

--- a/src/opnsense/mvc/tests/api/auth_add_user.sh
+++ b/src/opnsense/mvc/tests/api/auth_add_user.sh
@@ -1,0 +1,69 @@
+#!/bin/sh
+set -eu
+
+SCRIPT=/usr/local/opnsense/scripts/auth/add_user.php
+USERNAME=${OPNSENSE_TEST_USERNAME:-addusertest$$}
+ORIGIN=${OPNSENSE_TEST_ORIGIN:-regression-test}
+LOG=$(find /var/log/configd -type f -name 'configd_*.log' | sort | tail -n 1)
+START_LINE=$(wc -l < "$LOG" | tr -d ' ')
+
+cleanup() {
+    status=$?
+    trap - EXIT HUP INT TERM
+    php -r '
+        require_once("legacy_bindings.inc");
+        $username = $argv[1];
+        $config = OPNsense\Core\Config::getInstance();
+        $config->lock();
+        $model = new OPNsense\Auth\User();
+        $changed = false;
+        foreach ($model->user->iterateItems() as $uuid => $user) {
+            if ((string)$user->name === $username) {
+                $changed = $model->user->del($uuid) || $changed;
+            }
+        }
+        if ($changed) {
+            $model->serializeToConfig(false, true);
+            $config->save();
+        } else {
+            $config->unlock();
+        }
+        configdp_run("auth sync user", [$username]);
+    ' "$USERNAME" >/dev/null
+    exit "$status"
+}
+trap cleanup EXIT HUP INT TERM
+
+OUTPUT=$($SCRIPT -u "$USERNAME" -o "$ORIGIN")
+printf '%s' "$OUTPUT" | jq -e --arg name "$USERNAME" \
+    '.status == "ok" and .name == $name' >/dev/null
+
+echo "User creation: PASS"
+
+SCOPE=$(php -r '
+    $xml = simplexml_load_file("/conf/config.xml");
+    foreach ($xml->system->user as $user) {
+        if ((string)$user->name === $argv[1]) {
+            echo (string)$user->scope;
+        }
+    }
+' "$USERNAME")
+[ "$SCOPE" = "$ORIGIN" ]
+echo "Origin option: PASS"
+
+found=0
+for unused in 1 2 3 4 5; do
+    if tail -n +$((START_LINE + 1)) "$LOG" | grep -F "user $USERNAME changed" >/dev/null; then
+        found=1
+        break
+    fi
+    sleep 1
+done
+[ "$found" -eq 1 ]
+echo "Backend event username: PASS"
+
+DUPLICATE=$($SCRIPT -u "$USERNAME" -o "$ORIGIN")
+printf '%s' "$DUPLICATE" | jq -e '.status == "failed" and (.messages | length > 0)' >/dev/null
+echo "Duplicate validation: PASS"
+
+echo "All add-user tests passed"

--- a/src/opnsense/scripts/auth/add_user.php
+++ b/src/opnsense/scripts/auth/add_user.php
@@ -32,14 +32,13 @@ require_once('legacy_bindings.inc');
 use OPNsense\Core\Config;
 use OPNsense\Auth\User;
 
-$opts = getopt('hu:o', array(), $optind);
-$args = array_slice($argv, $optind);
+$opts = getopt('hu:o:', [], $optind);
 
 if (isset($opts['h']) || empty($opts['u'])) {
     echo "Usage: add_user.php [-h] \n";
     echo "\t-h show this help text and exit\n";
     echo "\t-u [required] username\n";
-    echo "\t-o origin (default=automation)";
+    echo "\t-o origin (default=automation)\n";
     exit(-1);
 } else {
     Config::getInstance()->lock();
@@ -70,7 +69,7 @@ if (isset($opts['h']) || empty($opts['u'])) {
         if ($usermdl->serializeToConfig(false, true)) {
             Config::getInstance()->save();
         }
-        configdp_run('auth user changed', [$userent['name']]);
+        configdp_run('auth user changed', [(string)$user->name]);
         echo json_encode(["status" => "ok", "uid" => (string)$user->uid, "name" => (string)$user->name]);
     } else {
         echo json_encode(["status" => "failed", "messages" => $input_errors]);


### PR DESCRIPTION
## Summary
- pass the created username to the backend user-changed event
- make `-o` require and preserve the supplied origin value
- add an integration regression test for creation, origin, backend event and duplicate handling
- synchronize the package plist for tests already present in the tree

## Validation
- PHP syntax check passed
- package plist check passed
- regression test passed on OPNsense-test
- built and installed `opnsense-26.7.1_15` successfully
