### PR TITLE
interfaces: fix VXLAN reconfiguration and API guardrails

### DIFF
--- a/plist
+++ b/plist
@@ -1082,6 +1082,7 @@
 /usr/local/opnsense/mvc/tests/api/interfaces_assignment_address_modes.sh
 /usr/local/opnsense/mvc/tests/api/interfaces_assignment_basic_settings.sh
 /usr/local/opnsense/mvc/tests/api/interfaces_assignment_static_addressing.sh
+/usr/local/opnsense/mvc/tests/api/interfaces_vxlan_guardrails.sh
 /usr/local/opnsense/mvc/tests/app/config/config.php
 /usr/local/opnsense/mvc/tests/app/library/OPNsense/Auth/ApiKeyCommandTest.php
 /usr/local/opnsense/mvc/tests/app/library/OPNsense/Core/ConfigConfig/backup/array.xml

--- a/plist
+++ b/plist
@@ -1140,6 +1140,7 @@
 /usr/local/opnsense/mvc/tests/app/models/OPNsense/Interfaces/NetworkInterfaceTest/config.xml
 /usr/local/opnsense/mvc/tests/app/models/OPNsense/Interfaces/VlanTest.php
 /usr/local/opnsense/mvc/tests/app/models/OPNsense/Interfaces/VlanTest/config.xml
+/usr/local/opnsense/mvc/tests/app/models/OPNsense/Interfaces/VxLanTest.php
 /usr/local/opnsense/mvc/tests/app/models/OPNsense/Kea/FieldTypes/KeaOptionDataFieldTest.php
 /usr/local/opnsense/mvc/tests/phpunit.xml
 /usr/local/opnsense/mvc/tests/setup.php

--- a/plist
+++ b/plist
@@ -1141,6 +1141,7 @@
 /usr/local/opnsense/mvc/tests/app/models/OPNsense/Interfaces/VlanTest.php
 /usr/local/opnsense/mvc/tests/app/models/OPNsense/Interfaces/VlanTest/config.xml
 /usr/local/opnsense/mvc/tests/app/models/OPNsense/Interfaces/VxLanTest.php
+/usr/local/opnsense/mvc/tests/app/models/OPNsense/Interfaces/VxLanTest/config.xml
 /usr/local/opnsense/mvc/tests/app/models/OPNsense/Kea/FieldTypes/KeaOptionDataFieldTest.php
 /usr/local/opnsense/mvc/tests/phpunit.xml
 /usr/local/opnsense/mvc/tests/setup.php

--- a/src/etc/inc/plugins.inc.d/vxlan.inc
+++ b/src/etc/inc/plugins.inc.d/vxlan.inc
@@ -82,7 +82,6 @@ function vxlan_configure_do($verbose = false, $device = null)
     // (re)configure vxlan devices
     foreach ($vxlans as $vxlan) {
         $device_name = "vxlan{$vxlan->deviceId}";
-        $isChanged = false;
 
         if ($device !== null && $device != $device_name) {
             $configured_devices[] = $device_name;
@@ -95,13 +94,10 @@ function vxlan_configure_do($verbose = false, $device = null)
         }
 
         $configured_devices[] = $device_name;
+        $device_exists = !empty($interfaces_details[$device_name]);
         $current_settings = [];
 
-        if (empty($interfaces_details[$device_name])) {
-            // new device
-            mwexecf('/sbin/ifconfig vxlan create name %s', array($device_name));
-            $isChanged = true;
-        } else {
+        if ($device_exists) {
             $current_settings['vxlanid'] = $interfaces_details[$device_name]['vxlan']['vni'];
             foreach (['local', 'remote', 'group'] as $target) {
                 if (!empty($interfaces_details[$device_name]['vxlan'][$target])) {
@@ -112,9 +108,10 @@ function vxlan_configure_do($verbose = false, $device = null)
             }
         }
 
-        // gather settings, detect changes
+        // gather desired settings
+        $desired_settings = [];
         $ifcnfcmd = '/sbin/ifconfig %s';
-        $ifcnfcmdp = array($device_name);
+        $ifcnfcmdp = [$device_name];
         foreach (
             [
             'vxlanid', 'vxlanlocal', 'vxlanremote', 'vxlanlocalport', 'vxlanremoteport', 'vxlangroup', 'vxlandev'
@@ -131,18 +128,18 @@ function vxlan_configure_do($verbose = false, $device = null)
             } else {
                 $value = (string)$vxlan->$param;
             }
+            $desired_settings[$param] = $value;
             if ($value != '') {
                 $ifcnfcmd .= " {$param} %s ";
                 $ifcnfcmdp[] = $value;
             }
-            if (isset($current_settings[$param]) && $current_settings[$param] != $value) {
-                // need to bring existing down to apply changes
-                mwexecf('/sbin/ifconfig %s down', [$device_name]);
-                $isChanged = true;
-            }
         }
 
-        if ($isChanged) {
+        if (!$device_exists || \OPNsense\Interfaces\VxLan::requiresRecreate($current_settings, $desired_settings)) {
+            if ($device_exists) {
+                mwexecf('/sbin/ifconfig %s destroy', [$device_name]);
+            }
+            mwexecf('/sbin/ifconfig vxlan create name %s', [$device_name]);
             mwexecf($ifcnfcmd . ' up', $ifcnfcmdp);
             $changed_devices[] = $device_name;
         }

--- a/src/opnsense/mvc/app/controllers/OPNsense/Interfaces/Api/VxlanSettingsController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Interfaces/Api/VxlanSettingsController.php
@@ -29,12 +29,27 @@
 namespace OPNsense\Interfaces\Api;
 
 use OPNsense\Core\Backend;
+use OPNsense\Core\Config;
+use OPNsense\Base\UserException;
 use OPNsense\Base\ApiMutableModelControllerBase;
 
 class VxlanSettingsController extends ApiMutableModelControllerBase
 {
     protected static $internalModelName = 'vxlan';
     protected static $internalModelClass = 'OPNsense\Interfaces\VxLan';
+
+    private function interfaceAssigned($if)
+    {
+        $configHandle = Config::getInstance()->object();
+        if (!empty($configHandle->interfaces)) {
+            foreach ($configHandle->interfaces->children() as $node) {
+                if ((string)$node->if == $if) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
 
     public function searchItemAction()
     {
@@ -56,9 +71,19 @@ class VxlanSettingsController extends ApiMutableModelControllerBase
         return $this->getBase("vxlan", "vxlan", $uuid);
     }
 
-    public function delItemAction($uuid)
+    public function delItemAction($uuids)
     {
-        return $this->delBase("vxlan", $uuid);
+        Config::getInstance()->lock();
+        foreach (!empty($uuids) ? explode(',', $uuids) : [] as $uuid) {
+            $node = $this->getModel()->getNodeByReference('vxlan.' . $uuid);
+            $device = $node != null ? 'vxlan' . (string)$node->deviceId : null;
+            if ($device != null && $this->interfaceAssigned($device)) {
+                throw new UserException(
+                    gettext("This VXLAN cannot be deleted because it is assigned as an interface.")
+                );
+            }
+        }
+        return $this->delBase("vxlan", $uuids);
     }
 
     public function reconfigureAction()

--- a/src/opnsense/mvc/app/models/OPNsense/Interfaces/VxLan.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Interfaces/VxLan.php
@@ -60,19 +60,61 @@ class VxLan extends BaseModel
         return false;
     }
 
+    public static function configurationKey(array $settings): string
+    {
+        foreach (['vxlanlocalport', 'vxlanremoteport'] as $parameter) {
+            if (empty($settings[$parameter])) {
+                $settings[$parameter] = '4789';
+            }
+        }
+        return implode("\0", [
+            (string)($settings['vxlanid'] ?? ''),
+            (string)($settings['vxlanlocal'] ?? ''),
+            (string)($settings['vxlanlocalport'] ?? ''),
+            (string)($settings['vxlanremote'] ?? ''),
+            (string)($settings['vxlanremoteport'] ?? ''),
+            (string)($settings['vxlangroup'] ?? ''),
+            (string)($settings['vxlandev'] ?? ''),
+        ]);
+    }
+
     public function performValidation($validateFullModel = false)
     {
         $messages = parent::performValidation($validateFullModel);
+        $items = iterator_to_array($this->vxlan->iterateItems());
+        $configurationKey = static function ($vxlan): string {
+            return self::configurationKey([
+                'vxlanid' => (string)$vxlan->vxlanid,
+                'vxlanlocal' => (string)$vxlan->vxlanlocal,
+                'vxlanlocalport' => (string)$vxlan->vxlanlocalport,
+                'vxlanremote' => (string)$vxlan->vxlanremote,
+                'vxlanremoteport' => (string)$vxlan->vxlanremoteport,
+                'vxlangroup' => (string)$vxlan->vxlangroup,
+                'vxlandev' => (string)$vxlan->vxlandev,
+            ]);
+        };
+        $configurationCounts = [];
+        foreach ($items as $vxlan) {
+            $signature = $configurationKey($vxlan);
+            $configurationCounts[$signature] = ($configurationCounts[$signature] ?? 0) + 1;
+        }
 
-        // Initialize variables
-        foreach ($this->vxlan->iterateItems() as $vxlan) {
+        foreach ($items as $vxlan) {
             $key = $vxlan->__reference;
-            $vxlangroup = (string) $vxlan->vxlangroup;
-            $vxlanremote = (string) $vxlan->vxlanremote;
-            $vxlandev = (string) $vxlan->vxlandev;
+            $vxlangroup = (string)$vxlan->vxlangroup;
+            $vxlanremote = (string)$vxlan->vxlanremote;
+            $vxlandev = (string)$vxlan->vxlandev;
 
             // Validate that values in Fields have been changed, prevents configuration save lockout when invalid data is present.
             if ($validateFullModel || $vxlan->isFieldChanged()) {
+                if ($configurationCounts[$configurationKey($vxlan)] > 1) {
+                    $messages->appendMessage(new Message(
+                        gettext("An identical VXLAN configuration already exists."),
+                        $key . ".vxlanid",
+                        "DuplicateConfiguration"
+                    ));
+                }
+
                 // Validation 1: At least one of vxlangroup and vxlanremote must be populated, but not both.
                 if (
                     (!empty($vxlangroup) && !empty($vxlanremote)) ||

--- a/src/opnsense/mvc/app/models/OPNsense/Interfaces/VxLan.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Interfaces/VxLan.php
@@ -33,6 +33,33 @@ use OPNsense\Base\BaseModel;
 
 class VxLan extends BaseModel
 {
+    public static function requiresRecreate(array $current, array $desired): bool
+    {
+        foreach (
+            ['vxlanid', 'vxlanlocal', 'vxlanlocalport', 'vxlanremote', 'vxlanremoteport', 'vxlangroup']
+            as $parameter
+        ) {
+            $currentValue = (string)($current[$parameter] ?? '');
+            $desiredValue = (string)($desired[$parameter] ?? '');
+            if (str_ends_with($parameter, 'port')) {
+                $currentValue = $currentValue !== '' ? $currentValue : '4789';
+                $desiredValue = $desiredValue !== '' ? $desiredValue : '4789';
+            }
+            if ($currentValue !== $desiredValue) {
+                return true;
+            }
+        }
+
+        if (
+            array_key_exists('vxlandev', $current) &&
+            (string)$current['vxlandev'] !== (string)($desired['vxlandev'] ?? '')
+        ) {
+            return true;
+        }
+
+        return false;
+    }
+
     public function performValidation($validateFullModel = false)
     {
         $messages = parent::performValidation($validateFullModel);

--- a/src/opnsense/mvc/tests/api/interfaces_vxlan_guardrails.sh
+++ b/src/opnsense/mvc/tests/api/interfaces_vxlan_guardrails.sh
@@ -1,0 +1,101 @@
+#!/bin/sh
+set -eu
+
+: "${OPNSENSE_API_KEY:?Set OPNSENSE_API_KEY}"
+: "${OPNSENSE_API_SECRET:?Set OPNSENSE_API_SECRET}"
+: "${OPNSENSE_VXLAN_TEST_UUID:?Set OPNSENSE_VXLAN_TEST_UUID}"
+
+BASE_URL=${OPNSENSE_URL:-http://127.0.0.1}
+TMPDIR=$(mktemp -d /tmp/vxlan-guardrails.XXXXXX)
+ORIGINAL="$TMPDIR/original.json"
+PAYLOAD="$TMPDIR/payload.json"
+DUPLICATE_UUID=
+ORIGINAL_DELETED=0
+
+api_request() {
+    method=$1
+    path=$2
+    data=${3-}
+    if [ "$method" = GET ]; then
+        curl -fsS -u "$OPNSENSE_API_KEY:$OPNSENSE_API_SECRET" "$BASE_URL$path"
+    else
+        curl -fsS -u "$OPNSENSE_API_KEY:$OPNSENSE_API_SECRET" \
+            -H 'Content-Type: application/json' -X "$method" \
+            -d "$data" "$BASE_URL$path"
+    fi
+}
+
+api_status() {
+    method=$1
+    path=$2
+    output=$3
+    curl -sS -u "$OPNSENSE_API_KEY:$OPNSENSE_API_SECRET" \
+        -H 'Content-Type: application/json' -X "$method" -d '{}' \
+        -o "$output" -w '%{http_code}' "$BASE_URL$path"
+}
+
+cleanup() {
+    status=$?
+    trap - EXIT HUP INT TERM
+    set +e
+    if [ -n "$DUPLICATE_UUID" ]; then
+        api_request POST "/api/interfaces/vxlan_settings/del_item/$DUPLICATE_UUID" '{}' >/dev/null
+    fi
+    if [ "$ORIGINAL_DELETED" -eq 1 ]; then
+        api_request POST '/api/interfaces/vxlan_settings/add_item' "$(cat "$PAYLOAD")" >/dev/null
+    fi
+    rm -rf "$TMPDIR"
+    exit "$status"
+}
+trap cleanup EXIT HUP INT TERM
+
+api_request GET "/api/interfaces/vxlan_settings/get_item/$OPNSENSE_VXLAN_TEST_UUID" > "$ORIGINAL"
+jq -e '.vxlan.deviceId and .vxlan.vxlanid and .vxlan.vxlanlocal' "$ORIGINAL" >/dev/null
+
+DEVICE="vxlan$(jq -r '.vxlan.deviceId' "$ORIGINAL")"
+api_request GET '/api/interfaces/assignment/search_item' > "$TMPDIR/assignments.json"
+jq -e --arg device "$DEVICE" '.rows | any(.if == $device)' \
+    "$TMPDIR/assignments.json" >/dev/null || {
+        echo "$DEVICE is not assigned; refusing destructive guard test" >&2
+        exit 1
+    }
+
+jq -c '{vxlan: {
+    vxlanid: .vxlan.vxlanid,
+    vxlanlocal: .vxlan.vxlanlocal,
+    vxlanlocalport: .vxlan.vxlanlocalport,
+    vxlanremote: .vxlan.vxlanremote,
+    vxlanremoteport: .vxlan.vxlanremoteport,
+    vxlangroup: .vxlan.vxlangroup,
+    vxlandev: (.vxlan.vxlandev | to_entries[]? | select(.value.selected == 1) | .key) // ""
+}}' "$ORIGINAL" > "$PAYLOAD"
+
+api_request POST '/api/interfaces/vxlan_settings/add_item' "$(cat "$PAYLOAD")" \
+    > "$TMPDIR/duplicate.json"
+if ! jq -e '.result == "failed" and (.validations | length > 0)' \
+    "$TMPDIR/duplicate.json" >/dev/null; then
+    DUPLICATE_UUID=$(jq -r '.uuid // empty' "$TMPDIR/duplicate.json")
+    echo "Exact duplicate VXLAN was accepted" >&2
+    cat "$TMPDIR/duplicate.json" >&2
+    exit 1
+fi
+echo "Duplicate configuration validation: PASS"
+
+HTTP_STATUS=$(api_status POST \
+    "/api/interfaces/vxlan_settings/del_item/$OPNSENSE_VXLAN_TEST_UUID" \
+    "$TMPDIR/delete.json")
+case "$HTTP_STATUS" in
+    2??)
+        ORIGINAL_DELETED=1
+        echo "Assigned VXLAN was deleted" >&2
+        cat "$TMPDIR/delete.json" >&2
+        exit 1
+        ;;
+esac
+
+api_request GET "/api/interfaces/vxlan_settings/get_item/$OPNSENSE_VXLAN_TEST_UUID" \
+    > "$TMPDIR/read-back.json"
+jq -e --arg device_id "$(jq -r '.vxlan.deviceId' "$ORIGINAL")" \
+    '.vxlan.deviceId == $device_id' "$TMPDIR/read-back.json" >/dev/null
+echo "Assigned VXLAN deletion guard: PASS"
+echo "All VXLAN guardrail API tests passed"

--- a/src/opnsense/mvc/tests/app/models/OPNsense/Interfaces/VxLanTest.php
+++ b/src/opnsense/mvc/tests/app/models/OPNsense/Interfaces/VxLanTest.php
@@ -28,10 +28,42 @@
 
 namespace tests\OPNsense\Interfaces;
 
+use OPNsense\Core\AppConfig;
+use OPNsense\Core\Config;
 use OPNsense\Interfaces\VxLan;
 
 class VxLanTest extends \PHPUnit\Framework\TestCase
 {
+    private string $configDir;
+
+    protected function setUp(): void
+    {
+        $this->configDir = sys_get_temp_dir() . '/vxlan-' . uniqid();
+        mkdir($this->configDir, 0700, true);
+        copy(__DIR__ . '/VxLanTest/config.xml', $this->configDir . '/config.xml');
+        (new AppConfig())->update('application.configDir', $this->configDir);
+        Config::getInstance()->forceReload();
+    }
+
+    protected function tearDown(): void
+    {
+        @unlink($this->configDir . '/config.xml');
+        @rmdir($this->configDir);
+    }
+
+    private function addVxlan(VxLan $model, int $deviceId, string $remote): void
+    {
+        $vxlan = $model->vxlan->Add();
+        $vxlan->deviceId = $deviceId;
+        $vxlan->vxlanid = '4242';
+        $vxlan->vxlanlocal = '172.31.255.1';
+        $vxlan->vxlanlocalport = '4789';
+        $vxlan->vxlanremote = $remote;
+        $vxlan->vxlanremoteport = '4789';
+        $vxlan->vxlangroup = '';
+        $vxlan->vxlandev = '';
+    }
+
     private array $settings = [
         'vxlanid' => '4242',
         'vxlanlocal' => '172.31.255.1',
@@ -83,4 +115,33 @@ class VxLanTest extends \PHPUnit\Framework\TestCase
         $desired['vxlandev'] = 'vtnet1';
         $this->assertTrue(VxLan::requiresRecreate($current, $desired));
     }
+
+    public function testDuplicateConfigurationIsRejected(): void
+    {
+        $model = new VxLan();
+        $this->addVxlan($model, 1, '172.31.255.2');
+        $this->addVxlan($model, 2, '172.31.255.2');
+
+        $duplicates = [];
+        foreach ($model->performValidation(true) as $message) {
+            if ($message->getMessage() === 'An identical VXLAN configuration already exists.') {
+                $duplicates[] = $message->getField();
+            }
+        }
+        $this->assertCount(2, $duplicates);
+    }
+
+    public function testSameVniWithDifferentRemoteIsAllowed(): void
+    {
+        $model = new VxLan();
+        $this->addVxlan($model, 1, '172.31.255.2');
+        $this->addVxlan($model, 2, '172.31.255.3');
+
+        $messages = [];
+        foreach ($model->performValidation(true) as $message) {
+            $messages[] = $message->getMessage();
+        }
+        $this->assertNotContains('An identical VXLAN configuration already exists.', $messages);
+    }
+
 }

--- a/src/opnsense/mvc/tests/app/models/OPNsense/Interfaces/VxLanTest.php
+++ b/src/opnsense/mvc/tests/app/models/OPNsense/Interfaces/VxLanTest.php
@@ -1,0 +1,86 @@
+<?php
+
+/*
+ * Copyright (C) 2026 Biptec
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace tests\OPNsense\Interfaces;
+
+use OPNsense\Interfaces\VxLan;
+
+class VxLanTest extends \PHPUnit\Framework\TestCase
+{
+    private array $settings = [
+        'vxlanid' => '4242',
+        'vxlanlocal' => '172.31.255.1',
+        'vxlanlocalport' => '4789',
+        'vxlanremote' => '172.31.255.2',
+        'vxlanremoteport' => '4789',
+        'vxlangroup' => '',
+        'vxlandev' => '',
+    ];
+
+    public function testUnchangedSettingsDoNotRequireRecreate(): void
+    {
+        $this->assertFalse(VxLan::requiresRecreate($this->settings, $this->settings));
+    }
+
+    public function testDefaultPortsAreNormalized(): void
+    {
+        $current = $this->settings;
+        unset($current['vxlanlocalport'], $current['vxlanremoteport']);
+        $this->assertFalse(VxLan::requiresRecreate($current, $this->settings));
+    }
+
+    public function testPortChangeRequiresRecreate(): void
+    {
+        $desired = $this->settings;
+        $desired['vxlanremoteport'] = '4790';
+        $this->assertTrue(VxLan::requiresRecreate($this->settings, $desired));
+    }
+
+    public function testEndpointChangeRequiresRecreate(): void
+    {
+        $desired = $this->settings;
+        $desired['vxlanremote'] = '172.31.255.3';
+        $this->assertTrue(VxLan::requiresRecreate($this->settings, $desired));
+    }
+
+    public function testVniChangeRequiresRecreate(): void
+    {
+        $desired = $this->settings;
+        $desired['vxlanid'] = '4243';
+        $this->assertTrue(VxLan::requiresRecreate($this->settings, $desired));
+    }
+
+    public function testKnownDeviceChangeRequiresRecreate(): void
+    {
+        $current = $this->settings;
+        $current['vxlandev'] = 'vtnet0';
+        $desired = $this->settings;
+        $desired['vxlandev'] = 'vtnet1';
+        $this->assertTrue(VxLan::requiresRecreate($current, $desired));
+    }
+}

--- a/src/opnsense/mvc/tests/app/models/OPNsense/Interfaces/VxLanTest/config.xml
+++ b/src/opnsense/mvc/tests/app/models/OPNsense/Interfaces/VxLanTest/config.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<opnsense>
+  <OPNsense>
+    <Interfaces>
+      <vxlans version="1.0.2"/>
+    </Interfaces>
+  </OPNsense>
+</opnsense>


### PR DESCRIPTION
## Summary
- recreate existing VXLAN devices when runtime parameters change
- reject exact duplicate VXLAN configurations
- prevent deletion while a VXLAN device is assigned to an interface

## Tests
- PHPUnit: VxLanTest (8 tests)
- package plist and PHP syntax checks
- installed opnsense-26.7.1_18 on two OPNsense servers
- changed an active VXLAN UDP port 4789 -> 4792 -> 4789 with bidirectional overlay ping
- API guardrail regression test passed on both servers
- temporary VNI 4243 removed; VNI 4242 remains active