### PR TITLE
Interfaces: support explicit assignment identifiers

### DIFF
--- a/src/etc/inc/util.inc
+++ b/src/etc/inc/util.inc
@@ -782,6 +782,9 @@ function get_primary_interface_from_list($iflist = null)
             break;
         }
     }
+    if ($ret === null && !empty($iflist)) {
+        $ret = reset($iflist);
+    }
 
     return $ret;
 }

--- a/src/opnsense/mvc/app/controllers/OPNsense/Interfaces/Api/AssignmentController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Interfaces/Api/AssignmentController.php
@@ -45,7 +45,18 @@ class AssignmentController extends ApiMutableModelControllerBase
 
     public function setItemAction($ifname)
     {
-        return $this->setBase("interface", "interface", $ifname);
+        if ($this->request->isPost() && $this->request->hasPost('interface')) {
+            $payload = $this->request->getPost('interface');
+            if (is_array($payload) && !empty($payload['identifier']) && $payload['identifier'] !== $ifname) {
+                return [
+                    'result' => 'failed',
+                    'validations' => [
+                        'interface.identifier' => gettext('The interface identifier is immutable after creation.')
+                    ]
+                ];
+            }
+        }
+        return $this->setBase("interface", "interface", $ifname, ['identifier' => $ifname]);
     }
 
     public function addItemAction()

--- a/src/opnsense/mvc/app/controllers/OPNsense/Interfaces/forms/dialogAssignment.xml
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Interfaces/forms/dialogAssignment.xml
@@ -11,8 +11,8 @@
     <field>
         <id>interface.identifier</id>
         <label>Identifier</label>
-        <type>info</type>
-        <help>Technical identifier of the interface, used by hasync for example.</help>
+        <type>text</type>
+        <help>Stable technical identifier. Leave empty when creating an assignment to use automatic optN allocation. The identifier cannot be changed after creation.</help>
     </field>
     <field>
         <id>interface.lock</id>

--- a/src/opnsense/mvc/app/library/OPNsense/Firewall/Rule.php
+++ b/src/opnsense/mvc/app/library/OPNsense/Firewall/Rule.php
@@ -53,7 +53,7 @@ abstract class Rule
             foreach ($this->interfaceMapping as $ifname => $payload) {
                 if (!empty($payload['if'])) {
                     static::$aliasMap[$ifname] = sprintf("(%s:network)", $payload['if']);
-                    if (preg_match("/^(wan|lan|opt[0-9]+)$/", $ifname, $matches)) {
+                    if (Util::isConfiguredInterface($ifname)) {
                         static::$aliasMap[$ifname . 'ip'] = sprintf("(%s)", $payload['if']);
                     }
                 }

--- a/src/opnsense/mvc/app/library/OPNsense/Firewall/SNatRule.php
+++ b/src/opnsense/mvc/app/library/OPNsense/Firewall/SNatRule.php
@@ -91,12 +91,12 @@ class SNatRule extends Rule
                     $this->log('SNAT / pool type not round-robin');
                     $rule['disabled'] = true;
                 }
-            } elseif (preg_match("/^(wan|lan|opt[0-9]+)ip$/", $rule['target'], $matches)) {
-                if (empty($this->interfaceMapping["{$matches[1]}"])) {
+            } elseif (preg_match("/^([a-z][a-z0-9_]*)ip$/", $rule['target'], $matches) && Util::isConfiguredInterface($matches[1])) {
+                if (empty($this->interfaceMapping[$matches[1]])) {
                     $this->log("SNAT / target missing");
                     $rule['disabled'] = true;
                 } else {
-                    $rule['target'] = "({$this->interfaceMapping["{$matches[1]}"]['if']}:0)";
+                    $rule['target'] = "({$this->interfaceMapping[$matches[1]]['if']}:0)";
                 }
             }
             foreach (array("sourceport", "dstport", "natport") as $fieldname) {

--- a/src/opnsense/mvc/app/library/OPNsense/Firewall/Util.php
+++ b/src/opnsense/mvc/app/library/OPNsense/Firewall/Util.php
@@ -38,6 +38,14 @@ use OPNsense\Firewall\Alias;
 class Util
 {
     /**
+     * Test whether a name is a configured logical interface identifier.
+     */
+    public static function isConfiguredInterface(string $interface): bool
+    {
+        return isset(Config::getInstance()->object()->interfaces->{$interface});
+    }
+
+    /**
      * @var null|Alias reference to alias object
      */
     private static $aliasObject = null;
@@ -683,6 +691,9 @@ class Util
                 $lockout_if = $if;
                 break;
             }
+        }
+        if (empty($lockout_if) && !empty($iflist)) {
+            $lockout_if = reset($iflist);
         }
         if (empty($lockout_if)) {
             return [];

--- a/src/opnsense/mvc/app/models/OPNsense/Interfaces/NetworkInterface.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Interfaces/NetworkInterface.php
@@ -56,6 +56,12 @@ class NetworkInterface extends BaseModel
     ];
     private const MANAGED_IPV4_MODES = ['none', 'static', 'dhcp'];
     private const MANAGED_IPV6_MODES = ['none', 'static', 'linklocal', 'slaac', 'dhcp6', 'track6', 'idassoc6'];
+    private const IDENTIFIER_PATTERN = '/^[a-z][a-z0-9_]{0,31}$/';
+
+    private function identifier_is_reserved($identifier)
+    {
+        return in_array($identifier, ['lan', 'wan']) || preg_match('/^opt[0-9]+$/', $identifier);
+    }
 
     private function address_mode($address, $family)
     {
@@ -240,6 +246,7 @@ class NetworkInterface extends BaseModel
             $node = $this->interface->add($key);
             $node->descr = (string)$intf->descr;
             $node->identifier = $key;
+            $node->identifier->markUnchanged();
             $node->lock = empty((string)$intf->lock) ? '0' : '1';
             foreach (array_merge(self::RECONFIGURE_FIELDS, self::FILTER_FIELDS) as $field) {
                 if (in_array($field, self::BOOLEAN_FIELDS)) {
@@ -352,7 +359,16 @@ class NetworkInterface extends BaseModel
 
         foreach ($interfaces as $key => $intf) {
             if (!isset(Config::getInstance()->object()->interfaces->$key)) {
-                $new_key = 'opt' . $next_if;
+                $requested_key = trim($intf['identifier']);
+                if ($requested_key !== '') {
+                    $new_key = $requested_key;
+                } else {
+                    while (in_array('opt' . $next_if, $existing_ifnames)) {
+                        $next_if++;
+                    }
+                    $new_key = 'opt' . $next_if;
+                    $next_if++;
+                }
                 $newif = Config::getInstance()->object()->interfaces->addChild($new_key);
                 $newif->if = $intf['if'];
                 $newif->descr = $intf['descr'];
@@ -367,7 +383,7 @@ class NetworkInterface extends BaseModel
                 $this->serialize_family($newif, $model_interfaces[$key], $intf, 4);
                 $this->serialize_family($newif, $model_interfaces[$key], $intf, 6);
                 $this->store_if_todo($new_key, ['pending_action' => 'reconfigure']);
-                $next_if++;
+                $existing_ifnames[] = $new_key;
             }
         }
         return true;
@@ -376,11 +392,39 @@ class NetworkInterface extends BaseModel
     public function performValidation($validateFullModel = false)
     {
         $messages = parent::performValidation($validateFullModel);
+        $pending_identifiers = [];
         foreach ($this->interface->iterateItems() as $ifname => $if) {
             if (!$validateFullModel && !$if->isFieldChanged()) {
                 continue;
             }
             $key = $if->__reference;
+            $identifier = trim($if->identifier->getValue());
+            $is_existing = isset(Config::getInstance()->object()->interfaces->$ifname);
+            if ($is_existing && $identifier !== $ifname) {
+                $messages->appendMessage(new Message(
+                    gettext('The interface identifier is immutable after creation.'),
+                    $key . '.identifier'
+                ));
+            } elseif (!$is_existing && $identifier !== '') {
+                if (!preg_match(self::IDENTIFIER_PATTERN, $identifier)) {
+                    $messages->appendMessage(new Message(
+                        gettext('The interface identifier must start with a lowercase letter and contain only lowercase letters, digits, and underscores (maximum 32 characters).'),
+                        $key . '.identifier'
+                    ));
+                } elseif ($this->identifier_is_reserved($identifier)) {
+                    $messages->appendMessage(new Message(
+                        gettext('The interface identifier is reserved for automatic or built-in interface assignments.'),
+                        $key . '.identifier'
+                    ));
+                } elseif (isset(Config::getInstance()->object()->interfaces->$identifier) || isset($pending_identifiers[$identifier])) {
+                    $messages->appendMessage(new Message(
+                        gettext('The interface identifier is already in use.'),
+                        $key . '.identifier'
+                    ));
+                } else {
+                    $pending_identifiers[$identifier] = true;
+                }
+            }
             foreach ([
                 4 => ['type', 'ipaddr', 'subnet', 'gateway', 'inet', self::MANAGED_IPV4_MODES],
                 6 => ['type6', 'ipaddrv6', 'subnetv6', 'gatewayv6', 'inet6', self::MANAGED_IPV6_MODES]

--- a/src/opnsense/mvc/app/models/OPNsense/Interfaces/NetworkInterface.xml
+++ b/src/opnsense/mvc/app/models/OPNsense/Interfaces/NetworkInterface.xml
@@ -1,6 +1,6 @@
 <model>
     <mount>:memory:</mount>
-    <version>0.0.4</version>
+    <version>0.0.5</version>
     <description>Interface assignments</description>
     <items>
         <interface type="ArrayField">

--- a/src/opnsense/mvc/app/views/OPNsense/Interface/assignment.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Interface/assignment.volt
@@ -41,6 +41,13 @@
                 }
             }
         );
+        $('#{{formGridAssignment["edit_dialog_id"]}}').on('opnsense_bootgrid_mapped', function(e, actionType) {
+            const identifier = $('#interface\\.identifier');
+            identifier.prop('readonly', actionType !== 'add');
+            if (actionType === 'add') {
+                identifier.val('');
+            }
+        });
         $("#reconfigureAct").SimpleActionButton();
 
     });

--- a/src/opnsense/mvc/tests/app/models/OPNsense/Interfaces/NetworkInterfaceTest.php
+++ b/src/opnsense/mvc/tests/app/models/OPNsense/Interfaces/NetworkInterfaceTest.php
@@ -131,6 +131,61 @@ class NetworkInterfaceTest extends \PHPUnit\Framework\TestCase
         $this->assertNotEmpty($model->performValidation()->getMessages());
     }
 
+    public function testNewInterfaceUsesExplicitIdentifier(): void
+    {
+        $model = $this->newModel();
+        $node = $model->interface->add();
+        $node->identifier->setValue('transit');
+        $node->if->setValue('em1');
+        $node->descr->setValue('Transit');
+        $node->enable->setValue('1');
+        $this->assertEmpty($model->performValidation()->getMessages());
+        $this->assertTrue($model->serializeToConfig());
+
+        $config = Config::getInstance()->object()->interfaces->transit;
+        $this->assertSame('em1', (string)$config->if);
+        $this->assertSame('Transit', (string)$config->descr);
+        $this->assertSame('reconfigure', $model->get_if_todo()['transit']['pending_action']);
+        $this->assertFalse(isset(Config::getInstance()->object()->interfaces->opt1));
+    }
+
+    public function testExplicitIdentifierValidation(): void
+    {
+        foreach (['Transit', 'transit-net', 'wan', 'lan', 'opt1'] as $identifier) {
+            $model = $this->newModel();
+            $node = $model->interface->add();
+            $node->identifier->setValue($identifier);
+            $node->if->setValue('em1');
+            $node->descr->setValue('TEST');
+            $this->assertNotEmpty(
+                $model->performValidation()->getMessages(),
+                sprintf('identifier %s should be rejected', $identifier)
+            );
+        }
+    }
+
+    public function testDuplicateExplicitIdentifierIsRejected(): void
+    {
+        $config = Config::getInstance()->object()->interfaces->addChild('transit');
+        $config->if = 'em2';
+        $config->descr = 'Existing transit';
+
+        $model = $this->newModel();
+        $node = $model->interface->add();
+        $node->identifier->setValue('transit');
+        $node->if->setValue('em1');
+        $node->descr->setValue('Duplicate transit');
+        $this->assertNotEmpty($model->performValidation()->getMessages());
+    }
+
+    public function testExistingIdentifierIsImmutable(): void
+    {
+        $model = $this->newModel();
+        $node = $model->getNodeByReference('interface.wan');
+        $node->identifier->setValue('transit');
+        $this->assertNotEmpty($model->performValidation()->getMessages());
+    }
+
     public function testNewInterfaceCopiesBasicSettingsAndSchedulesApply(): void
     {
         $model = $this->newModel();


### PR DESCRIPTION
## Summary
- add stable semantic identifiers for interface assignments while preserving automatic `optN` allocation
- reject reserved `lan`, `wan`, and `optN` identifiers and make identifiers immutable after creation
- expose identifier creation in WebUI (editable on Add, readonly on Edit)
- resolve semantic interface identifiers in firewall dynamic addresses and source NAT
- preserve primary-interface / anti-lockout fallback for semantic-only configurations

## Validation
Disposable OPNsense VM `919000072` on `vmbr1`, verified against base `d46297de` before installing the candidate.

- model runtime: explicit create, auto `optN`, invalid/reserved, duplicate, immutable — PASS
- API: explicit/auto create, guardrails, immutable update — PASS
- authenticated WebUI assignment flow — PASS
- reboot persistence and post-reboot API/WebUI — PASS
- filter and source NAT apply — PASS
- active PF diagnostics: semantic `provider_test` rendered as physical `vlan02`
  - filter: `pass ... on vlan02 ... from (vlan02:network:*) to (vlan02:*)`
  - NAT: `nat on vlan02 ... from 198.51.100.0/24 -> (vlan02:0)`
- delete/recreate of the same explicit identifier — PASS
- cleanup: test PF rules removed; assignment list returned to management `lan` only
- XML parse and `git diff --check` — PASS

The existing explicit `/interfaces/assignment/reconfigure` apply boundary is intentionally unchanged.
