### PR TITLE
interfaces: restore VLAN device reload compatibility

### DIFF
--- a/src/etc/inc/interfaces.inc
+++ b/src/etc/inc/interfaces.inc
@@ -107,31 +107,20 @@ function interfaces_vlan_priorities()
     return $priorities;
 }
 
-function interfaces_vlan_configure($verbose = false)
+function interfaces_vlan_configure($device)
 {
-    global $config;
+    $vlans = config_read_array('vlans', 'vlan', false);
+    $all_parents = [];
 
-    if (!isset($config['vlans']['vlan'])) {
+    if (!count($vlans)) {
         return;
     }
 
-    service_log('Configuring VLAN interfaces...', $verbose);
-
-    /* XXX sorting vlans here on top of $config seems prone to further side effects */
-    // Handle QinQ dependencies by sorting list of vlans to create (first all vlans so we can stack QinQ on top)
-    usort($config['vlans']['vlan'], function ($a, $b) {
-        $aqinq = strpos($a['vlanif'], 'vlan') !== false ? 0 : 1;
-        $bqinq = strpos($b['vlanif'], 'vlan') !== false ? 0 : 1;
-        if ($aqinq === $bqinq) {
-            return $a['vlanif'] <=> $b['vlanif'];
-        } else {
-            return $aqinq <=> $bqinq;
-        }
-    });
-
-    /* requested vlan protocol, when the vlan has vlans as children, the 802.1ad (QinQ) proto should be used */
-    $all_parents = [];
-    foreach ($config['vlans']['vlan'] as $vlan) {
+    /*
+     * Requested VLAN protocol: when the VLAN has vlans as
+     * children, the 802.1ad (QinQ) proto should be used.
+     */
+    foreach ($vlans as $vlan) {
         if (!in_array($vlan['vlanif'], $all_parents)) {
             if (!isset($all_parents[$vlan['if']])) {
                 $all_parents[$vlan['if']] = 0;
@@ -139,14 +128,17 @@ function interfaces_vlan_configure($verbose = false)
             $all_parents[$vlan['if']]++;
         }
     }
-    foreach ($config['vlans']['vlan'] as $vlan) {
-        if (empty($vlan['proto'])) {
-            $vlan['proto'] = empty($all_parents[$vlan['vlanif']]) ? '802.1q' : '802.1ad';
-        }
-        _interfaces_vlan_configure($vlan);
-    }
 
-    service_log("done.\n", $verbose);
+    foreach ($vlans as $vlan) {
+        if ($vlan['vlanif'] == $device) {
+            /* XXX if we migrate this we don't have to deal with it anymore */
+            if (empty($vlan['proto'])) {
+                $vlan['proto'] = empty($all_parents[$vlan['vlanif']]) ? '802.1q' : '802.1ad';
+            }
+
+            _interfaces_vlan_configure($vlan);
+        }
+    }
 }
 
 function _interfaces_vlan_configure($vlan)
@@ -741,14 +733,21 @@ function interfaces_configure($verbose = false)
 
     interfaces_loopback_configure($verbose);
     interfaces_lagg_configure($verbose);
-    interfaces_vlan_configure($verbose);
 
     /* run through priority lists */
     foreach ([$hardware, $virtual, $track6, $bridge, $dhcp6c] as $list) {
         foreach ($list as $device => $if) {
+            /* pre-op: configuring the underlying parents */
+            foreach (interface_parent_devices($device) as $parent) {
+                if (!empty($devices[$parent])) {
+                    log_msg("Device $parent required by $device, configuring now");
+                    call_user_func_array($devices[$parent], [$parent]);
+                    unset($devices[$parent]);
+                }
+            }
+
             /* pre-op: configuring the underlying device */
             if (!empty($devices[$device])) {
-                /* XXX devices could depend on other devices */
                 log_msg("Device $device required for $if, configuring now");
                 call_user_func_array($devices[$device], [$device]);
                 unset($devices[$device]);
@@ -767,11 +766,21 @@ function interfaces_configure($verbose = false)
         }
     }
 
+    /* resolve parent devices of unconfigured devices */
+    foreach (array_keys($devices) as $device) {
+        foreach (interface_parent_devices($device) as $parent) {
+            if (!empty($devices[$parent])) {
+                log_msg("Device $parent required by $device, configuring late");
+                call_user_func_array($devices[$parent], [$parent]);
+                unset($devices[$parent]);
+            }
+        }
+    }
+
     /* last but not least start all unconfigured devices */
-    foreach ($devices as $name => $function) {
-        /* XXX devices could depend on other devices */
-        log_msg("Device $name is not assigned, configuring late");
-        call_user_func_array($function, [$name]);
+    foreach (array_keys($devices) as $device) {
+        log_msg("Device $device is not assigned, configuring late");
+        call_user_func_array($devices[$device], [$device]);
     }
 }
 
@@ -3557,7 +3566,6 @@ function interface_parent_devices($device, $as_interface = false)
     $parents = [];
 
     if (strstr($device, 'vlan') || strstr($device, 'qinq')) {
-        /* XXX maybe if we have a qinq type return both parents? */
         foreach (config_read_array('vlans', 'vlan', false) as $vlan) {
             if ($device == $vlan['vlanif']) {
                 $parents[] = $vlan['if'];

--- a/src/etc/inc/plugins.inc.d/core.inc
+++ b/src/etc/inc/plugins.inc.d/core.inc
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * Copyright (C) 2018-2025 Deciso B.V.
+ * Copyright (C) 2018-2026 Deciso B.V.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -202,6 +202,7 @@ function core_devices()
     }
 
     $devices[] = [
+        'function' => 'interfaces_vlan_configure',
         'pattern' => '_vlan|^vlan|^qinq',
         'names' => $vlan_names,
         'volatile' => true,

--- a/src/opnsense/mvc/app/models/OPNsense/Interfaces/FieldTypes/VlanInterfaceField.php
+++ b/src/opnsense/mvc/app/models/OPNsense/Interfaces/FieldTypes/VlanInterfaceField.php
@@ -55,7 +55,6 @@ class VlanInterfaceField extends BaseListField
                     if (
                         strpos($ifname, "qinq") === 0 || strpos($ifname, "lo") === 0 || strpos($ifname, "enc") === 0 ||
                         strpos($ifname, "pflog") === 0 || strpos($ifname, "pfsync") === 0 ||
-                        strpos($ifname, "bridge") === 0 ||
                         in_array('pointopoint', $details['flags'])
                     ) {
                         continue;

--- a/src/opnsense/scripts/interfaces/reconfigure_vlans.php
+++ b/src/opnsense/scripts/interfaces/reconfigure_vlans.php
@@ -2,7 +2,7 @@
 <?php
 
 /*
- * Copyright (C) 2022-2023 Deciso B.V.
+ * Copyright (C) 2022-2026 Deciso B.V.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -61,22 +61,22 @@ foreach (config_read_array('vlans', 'vlan', false) as $vlan) {
 }
 
 /* handle existing vlans */
-foreach (legacy_interfaces_details() as $ifname => $ifdetails) {
-    if (empty($ifdetails['vlan'])) {
+foreach (legacy_interfaces_details() as $device => $details) {
+    if (empty($details['vlan'])) {
         continue;
     }
-    if (!isset($all_vlans[$ifname])) {
+    if (!isset($all_vlans[$device])) {
         continue;
     }
-    if (empty($all_vlans[$ifname])) {
+    if (empty($all_vlans[$device])) {
         /* option 1: removed vlan */
-        legacy_interface_destroy($ifname);
+        legacy_interface_destroy($device);
     } else {
-        $vlan = $all_vlans[$ifname];
+        $vlan = $all_vlans[$device];
         if (empty($vlan['proto'])) {
             $vlan['proto'] = empty($all_parents[$vlan['vlanif']]) ? '802.1q' : '802.1ad';
         }
-        $cvlan = $ifdetails['vlan'];
+        $cvlan = $details['vlan'];
         if ($vlan['tag'] != $cvlan['tag'] || $vlan['if'] != $cvlan['parent']) {
             /* option 2: changed vlan, unlink and relink */
             /*
@@ -96,15 +96,12 @@ foreach (legacy_interfaces_details() as $ifname => $ifdetails) {
             }
         }
     }
-    unset($all_vlans[$ifname]);
+    unset($all_vlans[$device]);
 }
 
 /* configure new */
-foreach ($all_vlans as $ifname => $vlan) {
-    if (!empty($vlan)) {
-        $vlan['proto'] = !in_array($vlan['if'], $all_parents) ? '802.1q' : '802.1ad';
-        _interfaces_vlan_configure($vlan);
-    }
+foreach (array_keys($all_vlans) as $device) {
+    interfaces_vlan_configure($device);
 }
 
 ifgroup_setup();


### PR DESCRIPTION
Restore the coordinated upstream VLAN device-resolution change from OPNsense core commit `137513cc25745e83702962beacc3de6b8cd19644` on top of current BIPTEC master.

Why: network-core-router FastTrack historically consumed the newer `core.inc` VLAN device hook from core `5fe7...`. PR #14 intentionally followed the accepted BIPTEC runtime lineage `d462...`, so merge `933808a...` does not contain that upstream 4-file change. Copying only `core.inc` would create a mixed runtime; this PR brings the complete upstream change (`interfaces.inc`, `core.inc`, `VlanInterfaceField.php`, `reconfigure_vlans.php`).

Validation:
- cherry-pick of upstream commit applied with no conflicts;
- `git diff --check` PASS;
- PHP lint PASS for all four modified files on disposable OPNsense runtime.

This is required before updating network-core-router FastTrack to a single canonical core SHA containing both explicit interface identifiers and VLAN device reload compatibility.