### PR TITLE
feat: add selective HA status synchronization

### DIFF
--- a/src/etc/inc/plugins.inc
+++ b/src/etc/inc/plugins.inc
@@ -376,8 +376,13 @@ function plugins_xmlrpc_sync()
         $func = sprintf('%s_xmlrpc_sync', $name);
         if (function_exists($func)) {
             foreach ($func() as $helper) {
-                if (!empty($helper['id']) && !empty($helper['section'])) {
+                $has_sync_handler = !empty($helper['section']) ||
+                    !empty($helper['sync_validate']) ||
+                    !empty($helper['sync_prepare']) ||
+                    !empty($helper['sync_finalize']);
+                if (!empty($helper['id']) && $has_sync_handler) {
                     $sync_settings[$helper['id']] = $helper;
+                    $sync_settings[$helper['id']]['section'] = $helper['section'] ?? '';
                     if (empty($helper['help'])) {
                         $sync_settings[$helper['id']]['help'] = sprintf(gettext('Synchronize the %s configuration to the other HA host.'), $helper['description']);
                     }

--- a/src/etc/rc.filter_synchronize
+++ b/src/etc/rc.filter_synchronize
@@ -251,17 +251,44 @@ function carp_sync_xml($url, $username, $password, $sections, $debug)
     return true;
 }
 
+function ha_sync_callback(array $sync_item, string $hook): void
+{
+    if (empty($sync_item[$hook])) {
+        return;
+    }
+    if (!is_string($sync_item[$hook]) || !is_callable($sync_item[$hook])) {
+        throw new RuntimeException(sprintf('HA synchronization callback %s is not callable', $hook));
+    }
+    $result = call_user_func($sync_item[$hook]);
+    if ($result === false || (is_array($result) && ($result['status'] ?? 'ok') !== 'ok')) {
+        throw new RuntimeException(trim((string)($result['message'] ?? sprintf('HA synchronization callback %s failed', $hook))));
+    }
+}
+
 if (!empty($config['hasync'])) {
     $hasync = $config['hasync'];
     $enable_debug = in_array('debug', $argv);
     $restart_services = in_array('restart_services', $argv);
     $pre_check_master = in_array('pre_check_master', $argv);
+    $requested_syncitems = null;
+    foreach ($argv as $argument) {
+        if (str_starts_with($argument, 'syncitems=')) {
+            if ($requested_syncitems !== null) {
+                throw new RuntimeException('syncitems may only be specified once');
+            }
+            $requested_syncitems = array_values(array_unique(array_filter(array_map(
+                'trim',
+                explode(',', substr($argument, strlen('syncitems=')))
+            ))));
+        }
+    }
     if (in_array('-h', $argv)) {
         // show help and exit
-        echo "rc.filter_synchronize [debug] [restart_services] [pre_check_master]\n";
+        echo "rc.filter_synchronize [debug] [restart_services] [pre_check_master] [syncitems=item1,item2]\n";
         echo "debug - enable debug output\n";
         echo "restart_services - restart remote configured services\n";
         echo "pre_check_master - exit when carp is not in master mode\n";
+        echo "syncitems - synchronize only listed items enabled in High Availability settings\n";
         exit;
     }
 
@@ -304,17 +331,37 @@ if (!empty($config['hasync'])) {
         }
     }
 
+    $available_syncitems = plugins_xmlrpc_sync();
+    $enabled_syncitems = array_values(array_filter(explode(',', $hasync['syncitems'] ?? '')));
+    if ($requested_syncitems !== null) {
+        if (count($requested_syncitems) === 0) {
+            throw new RuntimeException('selective HA synchronization requires at least one sync item');
+        }
+        foreach ($requested_syncitems as $syncitem) {
+            if (!isset($available_syncitems[$syncitem])) {
+                throw new RuntimeException(sprintf('unknown HA synchronization item %s', $syncitem));
+            }
+            if (!in_array($syncitem, $enabled_syncitems, true)) {
+                throw new RuntimeException(sprintf('HA synchronization item %s is not enabled in High Availability settings', $syncitem));
+            }
+        }
+        $syncitems = $requested_syncitems;
+    } else {
+        $syncitems = $enabled_syncitems;
+    }
+
     $sections = [];
-    $syncitems = array_filter(explode(',', $hasync['syncitems'] ?? ''));
-    foreach (plugins_xmlrpc_sync() as $cnf_key => $cnf) {
-        if (in_array($cnf_key, $syncitems)) {
+    $selected_syncitems = [];
+    foreach ($available_syncitems as $cnf_key => $cnf) {
+        if (in_array($cnf_key, $syncitems, true)) {
+            $selected_syncitems[$cnf_key] = $cnf;
             foreach (array_filter(explode(',', $cnf['section'] ?? '')) as $section) {
                 $sections[] = $section;
             }
         }
     }
 
-    if (count($sections) <= 0) {
+    if (count($selected_syncitems) <= 0) {
         log_msg("Nothing has been configured to be synched. Skipping....");
         exit;
     }
@@ -324,36 +371,64 @@ if (!empty($config['hasync'])) {
         exit;
     }
 
-    carp_sync_xml($synchronizeto, $username, $hasync['password'], $sections, $enable_debug);
+    foreach ($selected_syncitems as $sync_item) {
+        ha_sync_callback($sync_item, 'sync_validate');
+    }
+    foreach ($selected_syncitems as $sync_item) {
+        ha_sync_callback($sync_item, 'sync_prepare');
+    }
+
     $client = new SimpleXMLRPC_Client($synchronizeto, 240);
     $client->debug = $enable_debug;
     $client->setCredentials($username, $hasync['password']);
-    if ($client->query("opnsense.filter_configure")) {
-        $response = $client->getResponse();
-    } else {
-        // propagate error to log
-        log_msg("An error occurred while attempting XMLRPC sync with username {$username} and {$url} " . $client->error, LOG_ERR);
-        // print communication details on failure
-        echo $client->getDetails();
-        return false;
+    if (count($sections) > 0) {
+        carp_sync_xml($synchronizeto, $username, $hasync['password'], array_values(array_unique($sections)), $enable_debug);
+        if ($client->query("opnsense.filter_configure")) {
+            $response = $client->getResponse();
+        } else {
+            // propagate error to log
+            log_msg("An error occurred while attempting XMLRPC sync with username {$username} and {$url} " . $client->error, LOG_ERR);
+            // print communication details on failure
+            echo $client->getDetails();
+            return false;
+        }
+
+        if (!is_array($response) && trim($response) == "Authentication failed") {
+            log_msg("An authentication failure occurred while trying to access {$url}.", LOG_ERR);
+            exit;
+        }
     }
 
-    if (!is_array($response) && trim($response) == "Authentication failed") {
-        log_msg("An authentication failure occurred while trying to access {$url}.", LOG_ERR);
-        exit;
+    foreach ($selected_syncitems as $sync_item) {
+        ha_sync_callback($sync_item, 'sync_finalize');
     }
 
     if ($restart_services) {
-        $client->query('opnsense.configd_reload_all_templates', []);
-        if ($client->query('opnsense.list_services', [])) {
-            foreach ($client->getResponse() as $service) {
-                $client->query('opnsense.restart_service', [
-                    "service" => $service['name'],
-                    "id" => isset($service['id']) ? $service['name'] : ""
-                ]);
+        $services_to_restart = null;
+        if ($requested_syncitems !== null) {
+            $services_to_restart = [];
+            foreach ($selected_syncitems as $sync_item) {
+                $services_to_restart = array_merge($services_to_restart, $sync_item['services'] ?? []);
+            }
+            $services_to_restart = array_values(array_unique($services_to_restart));
+        }
+        if ($services_to_restart === null || count($services_to_restart) > 0) {
+            $client->query('opnsense.configd_reload_all_templates', []);
+            if ($client->query('opnsense.list_services', [])) {
+                foreach ($client->getResponse() as $service) {
+                    if ($services_to_restart === null || in_array($service['name'], $services_to_restart, true)) {
+                        $client->query('opnsense.restart_service', [
+                            "service" => $service['name'],
+                            "id" => isset($service['id']) ? $service['name'] : ""
+                        ]);
+                    }
+                }
             }
         }
     }
 
     log_msg("Filter sync successfully completed with {$synchronizeto}.");
+    if ($requested_syncitems !== null) {
+        echo "ok\n";
+    }
 }

--- a/src/opnsense/mvc/app/controllers/OPNsense/Core/Api/HasyncStatusController.php
+++ b/src/opnsense/mvc/app/controllers/OPNsense/Core/Api/HasyncStatusController.php
@@ -30,6 +30,7 @@ namespace OPNsense\Core\Api;
 
 use OPNsense\Base\ApiControllerBase;
 use OPNsense\Core\Backend;
+use OPNsense\Core\Hasync;
 
 /**
  * Class HasyncStatusController
@@ -50,10 +51,39 @@ class HasyncStatusController extends ApiControllerBase
         return json_decode((new Backend())->configdRun('system ha exec version'), true);
     }
 
+    private function selectedSyncItems(): array
+    {
+        $options = json_decode((new Backend())->configdRun('system ha options'), true);
+        if (!is_array($options)) {
+            return [];
+        }
+        $selected = array_filter(explode(',', (string)(new Hasync())->syncitems));
+        return array_intersect_key($options, array_flip($selected));
+    }
+
     public function servicesAction()
     {
         $data = json_decode((new Backend())->configdRun('system ha services_cached'), true);
         $records = !empty($data['response']) ? $data['response'] : [];
+        foreach ($this->selectedSyncItems() as $item => $description) {
+            $matched = false;
+            foreach ($records as &$record) {
+                if (strcasecmp(trim((string)($record['description'] ?? '')), trim((string)$description)) === 0) {
+                    $record['sync_item'] = $item;
+                    $matched = true;
+                    break;
+                }
+            }
+            unset($record);
+            if (!$matched) {
+                $records[] = [
+                    'name' => $item,
+                    'description' => $description,
+                    'sync_item' => $item,
+                    'nocheck' => true,
+                ];
+            }
+        }
         return $this->searchRecordsetBase($records, null, null, function (&$record) {
             $record['uid'] = $record['name'] ?? '';
             if (!empty($record['id'])) {
@@ -61,6 +91,40 @@ class HasyncStatusController extends ApiControllerBase
             }
             return true;
         });
+    }
+
+    public function syncAction()
+    {
+        $items = $this->request->getPost('items');
+        if (!$this->request->isPost() || !is_array($items)) {
+            return ['status' => 'failed', 'message' => 'one or more HA synchronization items are required'];
+        }
+        $requested = array_values(array_unique(array_filter(array_map(
+            fn($item) => is_string($item) ? trim($item) : '',
+            $items
+        ))));
+        if (count($requested) === 0 || array_filter($requested, fn($item) => !preg_match('/^[A-Za-z0-9_-]+$/D', $item))) {
+            return ['status' => 'failed', 'message' => 'invalid HA synchronization item'];
+        }
+
+        $selected = $this->selectedSyncItems();
+        foreach ($requested as $item) {
+            if (!isset($selected[$item])) {
+                return ['status' => 'failed', 'message' => sprintf('HA synchronization item %s is not enabled in High Availability settings', $item)];
+            }
+        }
+
+        $result = json_decode(
+            (new Backend())->configdpRun('system ha exec', ['exec_sync', implode(',', $requested), ''], false, 300),
+            true
+        );
+        if (!is_array($result) || ($result['status'] ?? '') !== 'ok') {
+            return [
+                'status' => 'failed',
+                'message' => is_array($result) ? trim((string)($result['message'] ?? 'HA synchronization failed')) : 'invalid HA synchronization response',
+            ];
+        }
+        return ['status' => 'ok', 'items' => $requested];
     }
 
     public function stopAction($service = null, $service_id = null)

--- a/src/opnsense/mvc/app/views/OPNsense/Core/hasync_status.volt
+++ b/src/opnsense/mvc/app/views/OPNsense/Core/hasync_status.volt
@@ -45,6 +45,18 @@
                                 let service_id = row.id ?? '';
                                 let service_name = row.name ?? '';
                                 let widget = [];
+                                if (row.sync_item) {
+                                    if (row.status) {
+                                        widget.push('<span class="btn btn-xs btn-success"><i class="fa fa-play fa-fw"></i></span>');
+                                        widget.push('&nbsp;');
+                                    }
+                                    widget.push(
+                                        '<span data-service_action="sync" data-sync_item="'+row.sync_item+'" class="btn btn-xs btn-default xmlrpc_srv_status_act">'+
+                                            '<i class="fa fa-repeat fa-fw"></i>' +
+                                        '</span>'
+                                    );
+                                    return widget.join('');
+                                }
                                 if (row.status) {
                                     widget.push(
                                         '<span class="btn btn-xs btn-success"><i class="fa fa-play fa-fw"></i></span>'
@@ -89,6 +101,9 @@
                             case 'restart':
                                 $(this).tooltip({title: "{{ lang._('Synchronize and Restart') | safe}}", container: "body", trigger: "hover"});
                                 break;
+                            case 'sync':
+                                $(this).tooltip({title: "{{ lang._('Synchronize') | safe}}", container: "body", trigger: "hover"});
+                                break;
                             case 'stop':
                                 $(this).tooltip({title: "{{ lang._('Stop') | safe}}", container: "body", trigger: "hover"});
                                 break;
@@ -100,7 +115,12 @@
                             }
                             $(this).find('i').removeClass('fa-play fa-stop fa-repeat').addClass('fa-spinner fa-pulse');
                             $(this).parent().find('span').addClass('locked');
-                            ajaxCall('/api/core/hasync_status/' + $(this).data('service_action') + '/' + $(this).data('service_name') + '/' + $(this).data('service_id'), {}, function(data){
+                            let action = $(this).data('service_action');
+                            let endpoint = action === 'sync'
+                                ? '/api/core/hasync_status/sync'
+                                : '/api/core/hasync_status/' + action + '/' + $(this).data('service_name') + '/' + $(this).data('service_id');
+                            let payload = action === 'sync' ? {items: [$(this).data('sync_item')]} : {};
+                            ajaxCall(endpoint, payload, function(data){
                                 $('#grid_services').bootgrid('reload');
                             });
                         });

--- a/src/opnsense/scripts/system/ha_xmlrpc_exec.php
+++ b/src/opnsense/scripts/system/ha_xmlrpc_exec.php
@@ -54,8 +54,16 @@ try {
             echo json_encode(['status' => 'done']);
             break;
         case 'exec_sync':
-            configd_run('filter sync');
-            echo json_encode(['status' => 'done']);
+            if ($service !== '') {
+                $result = trim(configdp_run('filter sync_selected', [$service]));
+                if ($result !== 'ok') {
+                    throw new \RuntimeException('selective HA configuration synchronization failed');
+                }
+                echo json_encode(['status' => 'ok']);
+            } else {
+                configd_run('filter sync');
+                echo json_encode(['status' => 'done']);
+            }
             break;
         case 'version':
             $payload = xmlrpc_execute('opnsense.firmware_version');

--- a/src/opnsense/service/conf/actions.d/actions_filter.conf
+++ b/src/opnsense/service/conf/actions.d/actions_filter.conf
@@ -10,6 +10,12 @@ parameters:
 type:script
 message:Syncing firewall %s
 
+[sync_selected]
+command:/usr/local/etc/rc.filter_synchronize
+parameters:syncitems=%s restart_services
+type:script_output
+message:Syncing selected HA configuration %s
+
 [refresh_aliases]
 command:/usr/local/bin/flock -n -E 0 -o /tmp/filter_update_tables.lock /usr/local/opnsense/scripts/filter/update_tables.py
 parameters:


### PR DESCRIPTION
## Summary
- extend the existing `rc.filter_synchronize` flow with an optional selective item set; the no-argument/full-sync path is unchanged
- use the existing XMLRPC sync descriptor `services` field to reconfigure only services related to a selective item
- allow plugin sync descriptors to supply validate/prepare/finalize callbacks when a policy-managed object cannot be represented as a raw config section
- add `POST /api/core/hasync_status/sync` as a thin API entry point to the same native HA engine
- add selected configuration items to the existing High Availability Status table; an already-existing service row is reused when it already has the same native description (for example `login / Users and Groups`)

## Deliberately unchanged
- `core_xmlrpc_sync()` / `src/etc/inc/plugins.inc.d/core.inc`
- the existing `system ha options` registry and model population path
- existing runtime service rows and their normal start/stop/restart path
- the existing full `Synchronize and reconfigure all` path

There is no parallel configuration-sync engine and no UI-specific metadata added to native sync descriptors.

## Validation
- PHP syntax checked with the actual OPNsense PHP runtime on test router `.90`
- Status API on `.90` reuses the native `login / Users and Groups` row without any `status_service` metadata and adds the six missing selected categories separately
- all seven selected categories pass individual selective synchronization on `.90/.91`
- multi-item selective sync passes
- disabled NAT fails closed
- native full `exec_sync -> filter sync` still returns `done`
